### PR TITLE
Fix links in share.html

### DIFF
--- a/layouts/partials/article_metadata.html
+++ b/layouts/partials/article_metadata.html
@@ -19,7 +19,7 @@
     {{ end }}
 
     {{ if ne $is_list 1 }}
-        {{ partial "share.html" . }}
+        {{ partial "share.html" $ }}
     {{ end }}
 
 </div>

--- a/layouts/partials/share.html
+++ b/layouts/partials/share.html
@@ -1,4 +1,4 @@
-{{ if not (isset .Site.Params "disable_sharing") }}
+{{ if not .Site.Params.disable_sharing }}
 <ul class="share">
     <li>
         <a class="facebook" href="https://www.facebook.com/sharer.php?u={{ .Permalink | html }}" target="_blank">


### PR DESCRIPTION
Fix links not being rendered in share.html partial due to wrong variable scoping.

Also improve reaction to disable_sharing parameter, it will now disable links only if set to true, and will not if it is declared, but set to false.