### PR TITLE
header.html: Use "default" to specify the language.

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ with .Site.LanguageCode }}{{ . }}{{ else }}en-US{{ end }}">
+<html lang="{{ .Site.LanguageCode | default "en-us" }}">
 <head>
 
     <meta charset="utf-8">


### PR DESCRIPTION
Usage of the new template function `default` in `header.html` (`default` is new in Hugo 0.16).