### PR TITLE
share.html: Apply aria-hidden to share-box

### DIFF
--- a/layouts/partials/share.html
+++ b/layouts/partials/share.html
@@ -1,5 +1,5 @@
 {{ if .Site.Params.sharing }}
-<div class="share-box">
+<div class="share-box" aria-hidden="true">
   <ul class="share">
     <li>
       <a class="facebook"


### PR DESCRIPTION
The share box is not accessible to screen readers (it does not contain
text). Thus, I excluded it from screen-readers via aria-hidden.