### PR TITLE
Added safeURL option to social icon links

### DIFF
--- a/layouts/partials/widgets/about.html
+++ b/layouts/partials/widgets/about.html
@@ -22,7 +22,7 @@
         {{ range $.Site.Params.social }}
         {{ $pack := or .icon_pack "fa" }}
         <li>
-          <a href="{{ .link }}">
+          <a href="{{ .link | safeURL }}">
             <i class="{{ $pack }} {{ $pack }}-{{ .icon }} big-icon"></i>
           </a>
         </li>


### PR DESCRIPTION
Added `safeURL` option (as in [1]) to social icon links to be able to use "non-safe" URIs (`bitcoin:` in my case).

[1] https://github.com/spf13/hugo/blob/0f6c73cf2ef3fa478a635b54652173eefa1f3a17/docs/content/templates/functions.md#safeurl