### PR TITLE
fixed archetype talk and added example talk to exampleSite

### DIFF
--- a/archetypes/talk.md
+++ b/archetypes/talk.md
@@ -3,6 +3,7 @@ math = false
 title = ""
 abstract = ""
 abstract_short = ""
+event = ""
 selected = false
 url_pdf = ""
 url_slides = ""

--- a/exampleSite/content/home/contact.md
+++ b/exampleSite/content/home/contact.md
@@ -9,7 +9,7 @@ subtitle = ""
 widget = "contact"
 
 # Order that this section will appear in.
-weight = 60
+weight = 70
 
 # Automatically link email and phone?
 autolink = true

--- a/exampleSite/content/home/posts.md
+++ b/exampleSite/content/home/posts.md
@@ -10,7 +10,7 @@ subtitle = ""
 widget = "posts"
 
 # Order that this section will appear in.
-weight = 30
+weight = 40
 
 # Show posts that contain the following tags. Default to any tags.
 tags = []

--- a/exampleSite/content/home/projects.md
+++ b/exampleSite/content/home/projects.md
@@ -10,7 +10,7 @@ subtitle = ""
 widget = "projects"
 
 # Order that this section will appear in.
-weight = 40
+weight = 50
 
 # View.
 # Customize how projects are displayed.

--- a/exampleSite/content/home/talks.md
+++ b/exampleSite/content/home/talks.md
@@ -1,0 +1,22 @@
++++
+# Recent Talks widget.
+# Note: this widget will only display if `content/talk/` contains talks.
+
+date = "2016-04-20T00:00:00"
+draft = false
+
+title = "Recent Talks"
+subtitle = ""
+widget = "talks"
+
+# Order that this section will appear in.
+weight = 30
+
+# Number of talks to list.
+count = 10
+
+# Show talk details (such as abstract)? (true/false)
+detailed_list = false
+
++++
+

--- a/exampleSite/content/home/teaching.md
+++ b/exampleSite/content/home/teaching.md
@@ -10,7 +10,7 @@ subtitle = ""
 widget = "custom"
 
 # Order that this section will appear in.
-weight = 50
+weight = 60
 
 +++
 

--- a/exampleSite/content/talk/example-talk.md
+++ b/exampleSite/content/talk/example-talk.md
@@ -1,5 +1,6 @@
 +++
-math = false
+date = "2016-12-22T00:00:00"
+math = true
 title = "Example Talk"
 abstract = ""
 abstract_short = ""

--- a/exampleSite/content/talk/example-talk.md
+++ b/exampleSite/content/talk/example-talk.md
@@ -1,0 +1,13 @@
++++
+math = false
+title = "Example Talk"
+abstract = ""
+abstract_short = ""
+event = "Hugo Academic Theme Conference"
+selected = false
+url_pdf = ""
+url_slides = ""
+url_video = ""
++++
+
+More detail can easily be written here using *Markdown* and $\rm \LaTeX$ math code.


### PR DESCRIPTION
The archetype for talks missed an "event" attribute, which is added
in this commit.
Additionally the exampleSite is updated to contain an example talk.