### PR TITLE
Change the weight of about.md from 0 to 1

### DIFF
--- a/exampleSite/content/home/about.md
+++ b/exampleSite/content/home/about.md
@@ -7,7 +7,7 @@ draft = false
 widget = "about"
 
 # Order that this section will appear in.
-weight = 0
+weight = 1
 
 # List your academic interests.
 [interests]


### PR DESCRIPTION
For some reason, the about widget is displayed at the very bottom on the homepage if weight = 0. Changing weight to 1 will move it to the top.

I'm using Hugo 0.18 on macOS. Not sure if it is a Hugo bug.