### PR TITLE
Fix broken smooth scroll.

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -28,7 +28,7 @@
           </a>
           <ul class="dropdown-menu">
             {{ range .Children }}
-            <li>
+            <li class="nav-item">
               <a href="{{ .URL | relURL }}"{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}>
                 {{ .Pre }}
                 <span>{{ .Name }}</span>
@@ -40,7 +40,7 @@
 
         {{ else }}
 
-        <li>
+        <li class="nav-item">
           <a href="{{ .URL | relURL }}"{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}>
             {{ .Pre }}
             <span>{{ .Name }}</span>


### PR DESCRIPTION
Commit 59116be74e14884d2fda2b5da3a32bb20174f9b1 has broken smooth scroll to widgets because of missing class specifiers.