### PR TITLE
Fix a741bc6 (missing card_text target specifier).

### DIFF
--- a/layouts/partials/widgets/projects.html
+++ b/layouts/partials/widgets/projects.html
@@ -66,7 +66,7 @@
           </a>
           {{ end }}
           <div class="card-text">
-            <h4><a href="{{ $.Scratch.Get "project_url" }}">{{ .Title }}</a></h4>
+            <h4><a href="{{ $.Scratch.Get "project_url" }}" {{ $.Scratch.Get "target" | safeHTMLAttr }}>{{ .Title }}</a></h4>
             <div class="card-desription">
               {{ with $project.Params.summary }}<p>{{ . | markdownify }}</p>{{ end }}
             </div>


### PR DESCRIPTION
Text link to project_url is not opening in new tab (unlike image link above) for external projects.