### PR TITLE
Add feature: Switch hides banner image in list

### DIFF
--- a/layouts/partials/post_li.html
+++ b/layouts/partials/post_li.html
@@ -2,11 +2,13 @@
 {{ $page := .page }}
 
 <div class="article-list-item" itemscope itemprop="blogPost">
-  {{ if $post.Params.image }}
-  <a href="{{ $post.Permalink }}">
-    <img src="{{ "/img/" | relURL }}{{ $post.Params.image }}" class="article-banner"
-    itemprop="image">
-  </a>
+  {{ if $post.Params.hide_banner_in_list }}
+  
+  {{ else if $post.Params.image }}
+    <a href="{{ $post.Permalink }}">
+      <img src="{{ "/img/" | relURL }}{{ $post.Params.image }}" class="article-banner"
+      itemprop="image">
+    </a>
   {{end}}
   <h3 class="article-title" itemprop="name">
     <a href="{{ $post.Permalink }}" itemprop="url">{{ $post.Title }}</a>
@@ -14,11 +16,11 @@
   {{ partial "article_metadata" (dict "content" $post "is_list" 1) }}
   <div class="article-style" itemprop="articleBody">
     {{ if $post.Params.summary }}
-    <p>{{ printf "%s" $post.Params.summary | markdownify }}</p>
+      <p>{{ printf "%s" $post.Params.summary | markdownify }}</p>
     {{ else if $post.Truncated }}
-    {{ $post.Summary }}
+      {{ $post.Summary }}
     {{ else }}
-    {{ $post.Content }}
+      {{ $post.Content }}
     {{ end }}
   </div>
   <p class="read-more">


### PR DESCRIPTION
Adds the functionality for a user to include an extra parameter in their post header to hide the banner image in a post list.

Currently, if an image is defined in the header, like `image = "example.png"`, then the banner image will appear in both the post and the post list. It is not possible (to my knowledge) to remove the image from the post list, but keep it in the actual post. This change would add this functionality.

With this change, the user could have the following line in their post header...

```
+++
image = "banners/example.png"
hide_banner_in_list = true
+++
```

... and the banner image will show on the post but not in the post list.

The naming I used for this new switch probably isn't great. It's a little long. However, I couldn't think of anything much better that would still be descriptive and understandable. Please change if you think of something better.

Cheers!