### PR TITLE
fix missed i18n in publication title

### DIFF
--- a/layouts/section/publication.html
+++ b/layouts/section/publication.html
@@ -3,7 +3,7 @@
 <div class="container">
   <div class="row">
     <div class="col-md-12">
-      <h1>{{ .Title | default "Publications" }}</h1>
+      <h1>{{ i18n "publications" | default "Publications" }}</h1>
 
       {{ with .Content }}
       <div class="article-style" itemprop="articleBody">{{ . }}</div>


### PR DESCRIPTION
Find out that the title is always in English. I fixed.