### PR TITLE
layout/sitemap: add alternate hreflang links when a page is translated

### DIFF
--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -1,8 +1,12 @@
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range (where .Data.Pages "Section" "!=" "home") }}
     {{ $perm := add $.Site.LanguagePrefix "/home/" }}
     {{ if ne .RelPermalink $perm }}
     <url>
+    {{ if .IsTranslated }}
+      <xhtml:link rel="alternate" href="{{ .Permalink }}" hreflang="{{ .Lang }}"/>{{ range .Translations }}
+      <xhtml:link rel="alternate" href="{{ .Permalink }}" hreflang="{{ .Lang }}"/>{{ end}}
+    {{ end }}
       <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
       <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
       <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -5,7 +5,7 @@
     <url>
     {{ if .IsTranslated }}
       <xhtml:link rel="alternate" href="{{ .Permalink }}" hreflang="{{ .Lang }}"/>{{ range .Translations }}
-      <xhtml:link rel="alternate" href="{{ .Permalink }}" hreflang="{{ .Lang }}"/>{{ end}}
+      <xhtml:link rel="alternate" href="{{ .Permalink }}" hreflang="{{ .Lang }}"/>{{ end }}
     {{ end }}
       <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
       <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}


### PR DESCRIPTION
We only add this in the sitemap and not in the header.
We can do one or the other but not both. Having this in the sitemap
avoid increasing the size of each page needlessly.

See https://support.google.com/webmasters/answer/2620865
See #67