### PR TITLE
footer: update MathJax cdn

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -56,7 +56,7 @@
     <script type="text/x-mathjax-config">
         MathJax.Hub.Config({ tex2jax: { inlineMath: [['$','$'], ['\\(','\\)']] } });
     </script>
-    <script async src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML"></script>
+    <script async src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS_CHTML"></script>
     {{ end }}
 
   </body>


### PR DESCRIPTION
MathJax CDN will shutdown, hence update to cloudflare cdn

See https://www.mathjax.org/cdn-shutting-down/