### PR TITLE
about: fix schema tag for the image

### DIFF
--- a/layouts/partials/widgets/about.html
+++ b/layouts/partials/widgets/about.html
@@ -7,9 +7,9 @@
     <div id="profile">
 
       {{ with $.Site.Params.avatar }}
-      <div class="portrait" itemprop="image"
-           style="background-image: url('{{ "/img/" | relURL }}{{ . }}');">
+      <div class="portrait" style="background-image: url('{{ "/img/" | relURL }}{{ . }}');">
       </div>
+      <meta itemprop="image" content="{{ "/img/" | relURL }}{{ . }}">
       {{ end }}
 
       <div class="portrait-title">


### PR DESCRIPTION
The image property is not set properly. It expects text or url but it
will not look in the background-image CSS property, thus it is not
found.

Fix this by adding an hidden meta element.