### PR TITLE
Fixed Bio Image

### DIFF
--- a/layouts/partials/widgets/about.html
+++ b/layouts/partials/widgets/about.html
@@ -10,8 +10,8 @@
       <div class="portrait" style="background-image: url('https://s.gravatar.com/avatar/{{ md5 $.Site.Params.email }}?s=200');"></div>
       <meta itemprop="image" content="https://s.gravatar.com/avatar/{{ md5 $.Site.Params.email }}?s=200">
       {{ else if $.Site.Params.avatar }}
-      <div class="portrait" style="background-image: url('{{ $.Site.BaseURL }}img/{{ $.Site.Params.avatar }}');"></div>
-      <meta itemprop="image" content="{{ $.Site.BaseURL }}img/{{ $.Site.Params.avatar }}">
+      <div class="portrait" style="background-image: url('{{ $.Site.BaseURL }}/img/{{ $.Site.Params.avatar }}');"></div>
+      <meta itemprop="image" content="{{ $.Site.BaseURL }}/img/{{ $.Site.Params.avatar }}">
       {{ end }}
 
       <div class="portrait-title">


### PR DESCRIPTION
Bio image wasn't loading because it was missing the forward slash before img.

This may have been just a personal thing with my domain, but it doesn't inherently have a forward slash after .com, which was causing the images to not load.