### PR TITLE
Fix css for button links

### DIFF
--- a/static/css/hugo-academic.css
+++ b/static/css/hugo-academic.css
@@ -761,8 +761,11 @@ footer a#back_to_top i {
   background: #0095eb;
 }
 
+.btn-primary:focus {
+  background: #fff;
+}
+
 .btn-primary:hover,
-.btn-primary:focus,
 .btn-primary:active,
 .btn-primary.active,
 .open > .dropdown-toggle.btn-primary {
@@ -826,6 +829,10 @@ footer a#back_to_top i {
 
 .btn-danger.btn-outline {
   color: #d9534f;
+}
+
+.btn-primary.btn-outline:focus {
+  color:#0095eb
 }
 
 .btn-primary.btn-outline:hover,


### PR DESCRIPTION
This fix prevents the button links that appear below publications from having the same foreground and background color when those links have focus, but are not being hovered over (e.g. after middle-clicking to open the link in a new window).