### PR TITLE
Add markdown in abstracts

### DIFF
--- a/layouts/partials/publication_li_detailed.html
+++ b/layouts/partials/publication_li_detailed.html
@@ -32,9 +32,9 @@
 
       <div class="pub-abstract" itemprop="text">
         {{ if .Params.abstract_short }}
-        {{ .Params.abstract_short }}
+        {{ .Params.abstract_short | markdownify }}
         {{ else }}
-        {{ .Params.abstract }}
+        {{ .Params.abstract | markdownify}}
         {{ end }}
       </div>
 

--- a/layouts/publication/single.html
+++ b/layouts/publication/single.html
@@ -24,7 +24,7 @@
   {{end}}
 
   <h3>{{ i18n "abstract" }}</h3>
-  <p class="pub-abstract" itemprop="text">{{ .Params.abstract }}</p>
+  <p class="pub-abstract" itemprop="text">{{ .Params.abstract | markdownify }}</p>
 
   {{ if (.Params.publication_types) and (ne (index .Params.publication_types 0) "0") }}
   <div class="row">


### PR DESCRIPTION
Added markdownify filter which allows the use of markdown in abstracts. This addresses #198 and #201.