### PR TITLE
Remove redundant disqus_thread

### DIFF
--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,7 +1,5 @@
 {{ if and .Site.DisqusShortname (not (or .Site.Params.disable_comments .Params.disable_comments)) }}
 <section id="comments">
-  <div id="disqus_thread">
-    {{ template "_internal/disqus.html" . }}
-  </div>
+  {{ template "_internal/disqus.html" . }}
 </section>
 {{ end }}


### PR DESCRIPTION
In` _internal/disqus.html`, there is already a disqus_thread div: https://github.com/gohugoio/hugo/blob/00b590d7ab4f3021814acceaf74c4eaf64edb226/tpl/tplimpl/template_embedded.go#L168