### PR TITLE
fix url_project link in multilingual mode

### DIFF
--- a/layouts/partials/publication_links.html
+++ b/layouts/partials/publication_links.html
@@ -32,7 +32,7 @@
 </a>
 {{ end }}
 {{ with $.Params.url_project }}
-<a class="btn btn-primary btn-outline{{ if $is_list }} btn-xs{{end}}" href="{{ . | absURL }}">
+<a class="btn btn-primary btn-outline{{ if $is_list }} btn-xs{{end}}" href="{{ . | absLangURL }}">
   {{ i18n "btn_project" }}
 </a>
 {{ end }}


### PR DESCRIPTION
If `url_project = "project/myprojectA"` in frontmatter, the link should be `/project/myprojectA/` in English lang, and `/zh/project/myprojectA` in Chinese lang.