### PR TITLE
Navbar fixed only on homepage; Fix smooth scrolling

### DIFF
--- a/layouts/partials/footer_container.html
+++ b/layouts/partials/footer_container.html
@@ -8,7 +8,7 @@
       theme</a> for <a href="http://gohugo.io" target="_blank">Hugo</a>.
 
       <span class="pull-right" aria-hidden="true">
-        <a href="#" id="back_to_top">
+        <a href="#top" id="back_to_top">
           <span class="button_icon">
             <i class="fa fa-chevron-up fa-2x"></i>
           </span>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -72,4 +72,9 @@
   <title>{{ if not .IsHome }}{{ .Title }} | {{ end }}{{ .Site.Title }}</title>
 
 </head>
-<body id="top" data-spy="scroll" data-target="#navbar-main" data-offset="71">
+
+{{ if or (eq .Kind "home") (in .Site.Params.fixed_nav_pages .Type)}}
+  <body id="top" data-spy="scroll" data-target="#navbar-main" data-offset="71" class="body-fixed-nav">
+{{ else }}
+  <body id="top">
+{{ end }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,4 +1,9 @@
-<nav class="navbar navbar-default navbar-fixed-top" id="navbar-main">
+{{ if or (eq .Kind "home") (in .Site.Params.fixed_nav_pages .Type)}}
+  <nav class="navbar navbar-default navbar-fixed-top-home" id="navbar-main">
+{{ else }}
+  <nav class="navbar navbar-default" id="navbar-main">
+{{ end }}
+
   <div class="container">
 
     <!-- Brand and toggle get grouped for better mobile display -->

--- a/static/css/hugo-academic.css
+++ b/static/css/hugo-academic.css
@@ -37,14 +37,9 @@ body {
   font-size: 1rem;
   line-height: inherit;
   color: inherit;
-  margin-top: 71px; /* Offset body content by navbar height. */
+  margin-top: 0;
   padding-top: 0;
   counter-reset: captions;
-}
-@media screen and (max-width: 1200px) { /* Match max-width of .nav-bar query. */
-  body {
-    margin-top: 51px; /* Offset body content by navbar height. */
-  }
 }
 
 /* Body text */
@@ -843,11 +838,28 @@ footer a#back_to_top i {
 
 .navbar {
   min-height: 70px !important;
+  margin-bottom: 0;  
+  border-width: 0 0 1px 0;
 }
+
+.navbar-fixed-top-home {
+  top: 0;
+  border-width: 0 0 1px;
+  position:fixed;
+  right: 0;
+  left: 0;
+}
+
+.body-fixed-nav,
+.body-add-margin { /* used in js to adjust body when navMenu is temproarily fixed (with .navbar-fixed-top)*/
+    margin-top:71px;
+}
+
 
 .navbar-default {
   background: #fff;
-  box-shadow: 0 0.125rem 0.25rem 0 rgba(0,0,0,.11)
+  box-shadow: 0 0.125rem 0.25rem 0 rgba(0,0,0,.11);
+  z-index:1030;
 }
 
 nav#navbar-main li {
@@ -911,6 +923,11 @@ nav#navbar-main li {
     min-height: 50px !important;
   }
 
+  .body-fixed-nav,
+  .body-add-margin {/* used in js to adjust body when navMenu is temproarily fixed (with .navbar-fixed-top)*/
+    margin-top:51px;
+  }
+
   .navbar-brand,
   .navbar-nav li a {
     height: inherit;
@@ -924,6 +941,14 @@ nav#navbar-main li {
     min-height: inherit;
   }
 
+  .navbar-fixed-top {/* same as bootstrap's def, but need to repeat here so it can over-ride .navbar-fixed-top-home when js applies this style */
+    top: 0;
+    border-width: 0 0 1px;
+    position:fixed;
+    right: 0;
+    left: 0;
+  }
+
   .navbar-left,
   .navbar-right {
     float: none !important;
@@ -931,11 +956,6 @@ nav#navbar-main li {
 
   .navbar-toggle {
     display: block;
-  }
-
-  .navbar-fixed-top {
-    top: 0;
-    border-width: 0 0 1px;
   }
 
   .navbar-collapse.collapse {


### PR DESCRIPTION
(1) Re-writes smooth-scrolling code to avoid duplication; resolves bug where scrollspy sometimes mis-tracked and where footnote links didn't smooth-scroll correctly;  This code also accommodates item (2) below.

(2) Navbar is fixed only on the homepage by default. (Configuration flags can be used to fix navbar on additional page types if desired.)

(3) On mobile, the navbar collapses when you click outside of it.  (Expand/Collapse code also accommodates item (2) above.)

Thanks for publishing a great theme!
