### PR TITLE
Multiple project widgets

### DIFF
--- a/layouts/partials/css/academic.css
+++ b/layouts/partials/css/academic.css
@@ -592,7 +592,7 @@ article {
   color: #9c9c9c;
 }
 
-#container-projects {
+.projects-container {
   display: block;
   position: relative;
   /*margin-top: 5rem;*/

--- a/layouts/partials/widgets/projects.html
+++ b/layouts/partials/widgets/projects.html
@@ -12,11 +12,11 @@
 
     {{ $filter_default := default (int $page.Params.filter_default) 0 }}
     {{ with $page.Params.filter }}
-    <span id="default-project-filter" class="hidden">{{ (index $page.Params.filter ($filter_default)).tag }}</span>
+    <span class="hidden default-project-filter">{{ (index $page.Params.filter ($filter_default)).tag }}</span>
     {{ end }}
 
     <div class="project-toolbar">
-      <div id="filters">
+      <div class="project-filters">
         <div class="btn-toolbar">
           <div class="btn-group">
             {{ range $idx, $item := $page.Params.filter }}
@@ -29,7 +29,7 @@
 
     {{ if eq $page.Params.view 0 }}
 
-    <div id="container-projects" class="row isotope">
+    <div class="row isotope projects-container">
         {{ range where $.Data.Pages "Type" "project" }}
         <div class="col-md-12 project-item isotope-item {{ delimit .Params.tags " " }}" itemscope itemtype="http://schema.org/CreativeWork">
           <i class="fa fa-files-o pub-icon" aria-hidden="true"></i>
@@ -50,7 +50,7 @@
 
     {{ else }}
 
-    <div id="container-projects" class="row isotope">
+    <div class="row isotope projects-container">
 
       {{ range $project := where $.Data.Pages "Type" "project" }}
       {{ $.Scratch.Set "project_url" $project.Permalink }}

--- a/layouts/partials/widgets/projects.html
+++ b/layouts/partials/widgets/projects.html
@@ -15,6 +15,7 @@
     <span class="hidden default-project-filter">{{ (index $page.Params.filter ($filter_default)).tag }}</span>
     {{ end }}
 
+    {{ if gt (len $page.Params.filter) 1 }}
     <div class="project-toolbar">
       <div class="project-filters">
         <div class="btn-toolbar">
@@ -26,6 +27,7 @@
         </div>
       </div>
     </div>
+    {{ end }}
 
     {{ if eq $page.Params.view 0 }}
 

--- a/static/js/hugo-academic.js
+++ b/static/js/hugo-academic.js
@@ -101,23 +101,26 @@
    * Filter projects.
    * --------------------------------------------------------------------------- */
 
-  let $grid_projects = $('#container-projects');
-  $grid_projects.imagesLoaded(function () {
-    // Initialize Isotope after all images have loaded.
-    $grid_projects.isotope({
-      itemSelector: '.isotope-item',
-      layoutMode: 'masonry',
-      filter: $('#default-project-filter').text()
-    });
+  $('.projects-container').each(function(index, container) {
+      let $container = $(container);
+      let $section = $container.closest('section');
 
-    // Filter items when filter link is clicked.
-    $('#filters a').click(function () {
-      let selector = $(this).attr('data-filter');
-      $grid_projects.isotope({filter: selector});
-      $(this).removeClass('active').addClass('active').siblings().removeClass('active all');
-      return false;
-    });
-  });
+      $container.imagesLoaded(function() {
+          // Initialize Isotope after all images have loaded.
+          $container.isotope({
+              itemSelector: '.isotope-item',
+              layoutMode: 'masonry',
+              filter: $section.find('.default-project-filter').text()
+          })
+          // Filter items when filter link is clicked.
+          $section.find('.project-filters a').click(function() {
+              let selector = $(this).attr('data-filter');
+              $container.isotope({filter: selector});
+              $(this).removeClass('active').addClass('active').siblings().removeClass('active all');
+              return false;
+          })
+      })
+  })
 
   /* ---------------------------------------------------------------------------
    * Filter publications.

--- a/static/js/hugo-academic.js
+++ b/static/js/hugo-academic.js
@@ -102,24 +102,24 @@
    * --------------------------------------------------------------------------- */
 
   $('.projects-container').each(function(index, container) {
-      let $container = $(container);
-      let $section = $container.closest('section');
+    let $container = $(container);
+    let $section = $container.closest('section');
 
-      $container.imagesLoaded(function() {
-          // Initialize Isotope after all images have loaded.
-          $container.isotope({
-              itemSelector: '.isotope-item',
-              layoutMode: 'masonry',
-              filter: $section.find('.default-project-filter').text()
-          })
-          // Filter items when filter link is clicked.
-          $section.find('.project-filters a').click(function() {
-              let selector = $(this).attr('data-filter');
-              $container.isotope({filter: selector});
-              $(this).removeClass('active').addClass('active').siblings().removeClass('active all');
-              return false;
-          })
+    $container.imagesLoaded(function() {
+      // Initialize Isotope after all images have loaded.
+      $container.isotope({
+        itemSelector: '.isotope-item',
+        layoutMode: 'masonry',
+        filter: $section.find('.default-project-filter').text()
       })
+      // Filter items when filter link is clicked.
+      $section.find('.project-filters a').click(function() {
+        let selector = $(this).attr('data-filter');
+        $container.isotope({filter: selector});
+        $(this).removeClass('active').addClass('active').siblings().removeClass('active all');
+        return false;
+      })
+    })
   })
 
   /* ---------------------------------------------------------------------------

--- a/static/js/hugo-academic.js
+++ b/static/js/hugo-academic.js
@@ -111,16 +111,16 @@
         itemSelector: '.isotope-item',
         layoutMode: 'masonry',
         filter: $section.find('.default-project-filter').text()
-      })
+      });
       // Filter items when filter link is clicked.
       $section.find('.project-filters a').click(function() {
         let selector = $(this).attr('data-filter');
         $container.isotope({filter: selector});
         $(this).removeClass('active').addClass('active').siblings().removeClass('active all');
         return false;
-      })
-    })
-  })
+      });
+    });
+  });
 
   /* ---------------------------------------------------------------------------
    * Filter publications.


### PR DESCRIPTION
This makes the project widget reusable and should resolve #100.
The basic idea is to dynamically create separate click handlers for the filter buttons of the various project widgets by using appropriate scoping of the variable which refers to the relevant project section.