### PR TITLE
publications: Link on Title and buttons on same line

### DIFF
--- a/layouts/partials/publication_li_classic.html
+++ b/layouts/partials/publication_li_classic.html
@@ -5,12 +5,12 @@
       {{- delimit . ", " | markdownify -}}
     {{- end -}}
   </span>.
-  <span itemprop="name">{{ .Title }}</span>.
+  <a itemprop="name" href="{{ $.Permalink }}">{{ .Title }}</a>.
   {{ if .Params.publication_short }}
     {{- .Params.publication_short | markdownify -}}
   {{ else }}
     {{- .Params.publication | markdownify -}}
   {{ end }},&nbsp;
   {{- .Date.Format "2006" -}}.
-  <p>{{ partial "publication_links" (dict "content" . "is_list" 1) }}</p>
+  {{ partial "publication_links" (dict "content" . "is_list" 1) }}
 </div>

--- a/layouts/partials/publication_li_simple.html
+++ b/layouts/partials/publication_li_simple.html
@@ -1,5 +1,5 @@
 <div class="pub-list-item" style="margin-bottom: 1rem" itemscope itemtype="http://schema.org/CreativeWork">
   <i class="fa fa-file-text-o pub-icon" aria-hidden="true"></i>
-  <span itemprop="name">{{ .Title }}</span>
-  <p>{{ partial "publication_links" (dict "content" . "is_list" 1) }}</p>
+  <a itemprop="name" href="{{ $.Permalink }}">{{ .Title }}</a>
+  {{ partial "publication_links" (dict "content" . "is_list" 1) }}
 </div>

--- a/layouts/partials/publication_links.html
+++ b/layouts/partials/publication_links.html
@@ -1,11 +1,6 @@
 {{ $is_list := .is_list }}
 {{ $ := .content }}
 
-{{ if $is_list }}
-<a class="btn btn-primary btn-outline btn-xs" href="{{ $.Permalink }}">
-  {{ i18n "btn_details" }}
-</a>
-{{ end }}
 {{ with $.Params.url_pdf }}
 <a class="btn btn-primary btn-outline{{ if $is_list }} btn-xs{{end}}" href="{{ . | absURL }}">
   {{ i18n "btn_pdf" }}

--- a/layouts/partials/widgets/about.html
+++ b/layouts/partials/widgets/about.html
@@ -62,7 +62,7 @@
         <h3>{{ i18n "interests" | markdownify }}</h3>
         <ul class="ul-interests">
           {{ range .interests }}
-          <li>{{ . }}</li>
+          <li>{{ . | markdownify }}</li>
           {{ end }}
         </ul>
       </div>
@@ -76,7 +76,7 @@
           <li>
             <i class="fa-li fa fa-graduation-cap"></i>
             <div class="description">
-              <p class="course">{{ .course }}{{ with .year }}, {{ . }}{{ end }}</p>
+              <p class="course">{{ .course | markdownify }}{{ with .year }}, {{ . }}{{ end }}</p>
               <p class="institution">{{ .institution }}</p>
             </div>
           </li>

--- a/layouts/partials/widgets/contact.html
+++ b/layouts/partials/widgets/contact.html
@@ -61,7 +61,7 @@
       {{ with $.Site.Params.address }}
       <li>
         <i class="fa-li fa fa-map-marker fa-2x" aria-hidden="true"></i>
-        <span id="person-address" itemprop="address">{{ . }}</span>
+        <span id="person-address" itemprop="address">{{ . | markdownify }}</span>
       </li>
       {{ end }}
 


### PR DESCRIPTION
This is a pretty basic suggestion for the **Publications list** widget.

Currently, the `Details` button is, in my opinion, lost among the other (`PDF`, `Video`, `Slides`...) buttons, which link to very different things: the same, internal page for `Details` vs. external, non HTML ressources for the others. Thus, I think `Details` should be visually distinguished from the others.

I initially tried to change the button appearance (e.g., with a `btn-default` class), but I don't feel it is enough.

My suggestion is thus to link the **Details** page on the **Title** of the publication and remove the `Details` button.

I would also suggest removing the linebreak before the text/title and the buttons in both _Simple_ and _Classic_ list views, so that the buttons are immediately after the text, as it often appears in this kind of publication list.

It would look like this:

![screenshot 2017-10-11 a 14 07 06](https://user-images.githubusercontent.com/4708459/31439740-8a2f4e14-ae8d-11e7-90c7-ef97a667c2c0.jpg)
