### PR TITLE
publication: fix date format

### DIFF
--- a/layouts/publication/single.html
+++ b/layouts/publication/single.html
@@ -64,7 +64,7 @@
       <div class="row">
         <div class="col-xs-12 col-sm-3 pub-row-heading">{{ i18n "date" }}</div>
         <div class="col-xs-12 col-sm-9" itemprop="datePublished">
-          {{ .Date.Format "January, 2006" }}
+          {{ .Date.Format $.Site.Params.date_format }}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Date format of publications should follow `date_format` in `config.toml`, especially for multilingual site, which may have different `date_format` for different languages.