### PR TITLE
Set projects to empty array in archetypes

### DIFF
--- a/archetypes/publication.md
+++ b/archetypes/publication.md
@@ -34,7 +34,7 @@ selected = false
 # Projects (optional).
 #   Associate this publication with one or more of your projects.
 #   Simply enter the filename (excluding '.md') of your project file in `content/project/`.
-projects = [""]
+projects = []
 
 # Links (optional).
 url_pdf = ""

--- a/archetypes/publication.md
+++ b/archetypes/publication.md
@@ -34,6 +34,7 @@ selected = false
 # Projects (optional).
 #   Associate this publication with one or more of your projects.
 #   Simply enter the filename (excluding '.md') of your project file in `content/project/`.
+#   E.g. `projects = ["deep-learning"]` references `content/project/deep-learning.md`.
 projects = []
 
 # Links (optional).

--- a/archetypes/talk.md
+++ b/archetypes/talk.md
@@ -25,7 +25,7 @@ selected = false
 # Projects (optional).
 #   Associate this talk with one or more of your projects.
 #   Simply enter the filename (excluding '.md') of your project file in `content/project/`.
-projects = [""]
+projects = []
 
 # Links (optional).
 url_pdf = ""

--- a/archetypes/talk.md
+++ b/archetypes/talk.md
@@ -25,6 +25,7 @@ selected = false
 # Projects (optional).
 #   Associate this talk with one or more of your projects.
 #   Simply enter the filename (excluding '.md') of your project file in `content/project/`.
+#   E.g. `projects = ["deep-learning"]` references `content/project/deep-learning.md`.
 projects = []
 
 # Links (optional).


### PR DESCRIPTION
`projects = [""]` is an array with one element. Thus, even if a publication doesn't belong to any project, the default value `projects = [""]` will always generate a project button, which links to `BASE_URL/project/`. 

Set `projects = []` as default can fix this issue.