### PR TITLE
Fix talk time format

### DIFF
--- a/layouts/partials/talk_li_detailed.html
+++ b/layouts/partials/talk_li_detailed.html
@@ -33,9 +33,9 @@
       <div class="talk-metadata" itemprop="startDate">
         {{ $date := .Params.time_start | default .Date }}
         {{ (time $date).Format $.Site.Params.date_format }}
-        {{ (time $date).Format "3:00 PM" }}
+        {{ (time $date).Format "3:04 PM" }}
         {{ with .Params.time_end }}
-        &mdash; {{ (time .).Format "3:00 PM" }}
+        &mdash; {{ (time .).Format "3:04 PM" }}
         {{ end }}
       </div>
 

--- a/layouts/partials/talk_li_simple.html
+++ b/layouts/partials/talk_li_simple.html
@@ -4,7 +4,7 @@
   <div itemprop="startDate">
     {{ $date := .Params.time_start | default .Date }}
     {{ (time $date).Format $.Site.Params.date_format }}
-    {{ (time $date).Format "3:00 PM" }}
+    {{ (time $date).Format "3:04 PM" }}
   </div>
   <div class="talk-metadata">
     {{ if .Params.event_short }}

--- a/layouts/talk/single.html
+++ b/layouts/talk/single.html
@@ -34,9 +34,9 @@
             {{ $date := .Params.time_start | default .Date }}
             {{ (time $date).Format $.Site.Params.date_format }}
             <div class="talk-time">
-              {{ (time $date).Format "3:00 PM" }}
+              {{ (time $date).Format "3:04 PM" }}
               {{ with .Params.time_end }}
-              &mdash; {{ (time .).Format "3:00 PM" }}
+              &mdash; {{ (time .).Format "3:04 PM" }}
               {{ end }}
             </div>
           </div>


### PR DESCRIPTION
`3:00 PM` can not format `minute` correctly. 

Reference: https://gohugo.io/functions/format/