### PR TITLE
time_format variable in config used in Talks

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -69,9 +69,11 @@ defaultContentLanguageInSubdir = false
   latitude = "37.4275"
   longitude = "-122.1697"
 
-  # Date format (refer to Go's date format: http://flippinggodateformat.com )
+  # Date and time format (refer to Go's date format: http://fuckinggodateformat.com )
   #   Examples: "Mon, Jan 2, 2006" or "2006-01-02"
   date_format = "Jan 2, 2006"
+  #   Examples: "3:04 pm" or "15:04"
+  time_format = "3:04 PM"
 
   # Show estimated reading time for posts?
   reading_time = true

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -145,7 +145,7 @@ defaultContentLanguageInSubdir = false
 
   # Configuration of publication pages.
   [params.publications]
-    # Date format (refer to Go's date format: http://flippinggodateformat.com )
+    # Date format (refer to Go's date format: http://fuckinggodateformat.com )
     #   Examples: "Mon, Jan 2, 2006" or "2006-01-02"
     date_format = "January, 2006"
 

--- a/layouts/partials/talk_li_detailed.html
+++ b/layouts/partials/talk_li_detailed.html
@@ -33,9 +33,9 @@
       <div class="talk-metadata" itemprop="startDate">
         {{ $date := .Params.time_start | default .Date }}
         {{ (time $date).Format $.Site.Params.date_format }}
-        {{ (time $date).Format $.Site.Params.time_format }}
+        {{ (time $date).Format ($.Site.Params.time_format | default "3:04 PM") }}
         {{ with .Params.time_end }}
-        &mdash; {{ (time .).Format $.Site.Params.time_format }}
+        &mdash; {{ (time .).Format ($.Site.Params.time_format | default "3:04 PM") }}
         {{ end }}
       </div>
 

--- a/layouts/partials/talk_li_detailed.html
+++ b/layouts/partials/talk_li_detailed.html
@@ -33,9 +33,9 @@
       <div class="talk-metadata" itemprop="startDate">
         {{ $date := .Params.time_start | default .Date }}
         {{ (time $date).Format $.Site.Params.date_format }}
-        {{ (time $date).Format "3:04 PM" }}
+        {{ (time $date).Format $.Site.Params.time_format }}
         {{ with .Params.time_end }}
-        &mdash; {{ (time .).Format "3:04 PM" }}
+        &mdash; {{ (time .).Format $.Site.Params.time_format }}
         {{ end }}
       </div>
 

--- a/layouts/partials/talk_li_simple.html
+++ b/layouts/partials/talk_li_simple.html
@@ -4,7 +4,7 @@
   <div itemprop="startDate">
     {{ $date := .Params.time_start | default .Date }}
     {{ (time $date).Format $.Site.Params.date_format }}
-    {{ (time $date).Format "3:04 PM" }}
+    {{ (time $date).Format $.Site.Params.time_format }}
   </div>
   <div class="talk-metadata">
     {{ if .Params.event_short }}

--- a/layouts/partials/talk_li_simple.html
+++ b/layouts/partials/talk_li_simple.html
@@ -4,7 +4,7 @@
   <div itemprop="startDate">
     {{ $date := .Params.time_start | default .Date }}
     {{ (time $date).Format $.Site.Params.date_format }}
-    {{ (time $date).Format $.Site.Params.time_format }}
+    {{ (time $date).Format ($.Site.Params.time_format | default "3:04 PM") }}
   </div>
   <div class="talk-metadata">
     {{ if .Params.event_short }}

--- a/layouts/talk/single.html
+++ b/layouts/talk/single.html
@@ -34,9 +34,9 @@
             {{ $date := .Params.time_start | default .Date }}
             {{ (time $date).Format $.Site.Params.date_format }}
             <div class="talk-time">
-              {{ (time $date).Format "3:04 PM" }}
+              {{ (time $date).Format $.Site.Params.time_format }}
               {{ with .Params.time_end }}
-              &mdash; {{ (time .).Format "3:04 PM" }}
+              &mdash; {{ (time .).Format $.Site.Params.time_format }}
               {{ end }}
             </div>
           </div>

--- a/layouts/talk/single.html
+++ b/layouts/talk/single.html
@@ -34,9 +34,9 @@
             {{ $date := .Params.time_start | default .Date }}
             {{ (time $date).Format $.Site.Params.date_format }}
             <div class="talk-time">
-              {{ (time $date).Format $.Site.Params.time_format }}
+              {{ (time $date).Format ($.Site.Params.time_format | default "3:04 PM") }}
               {{ with .Params.time_end }}
-              &mdash; {{ (time .).Format $.Site.Params.time_format }}
+              &mdash; {{ (time .).Format ($.Site.Params.time_format | default "3:04 PM") }}
               {{ end }}
             </div>
           </div>


### PR DESCRIPTION
- Added a time_format variable in config.toml (mainly to choose between am/pm or 24h format)
- time_format is used in displaying the time of Talks in lists and single pages
- Also corrected the reference to flippinggodateformat.com (unavailable since the end of 2016) to fuckinggodateformat.com