### PR TITLE
Fix home posts widget when a post has no tags

### DIFF
--- a/layouts/partials/widgets/posts.html
+++ b/layouts/partials/widgets/posts.html
@@ -57,16 +57,18 @@
 
         {{ $.Scratch.Set "show_post" "1" }}
 
-        {{/* If `tags_include` is set, exclude posts with no tags. */}}
-        {{ if and ($page.Params.tags_include) (lt (len .Params.tags) 1) }}
-          {{ $.Scratch.Set "show_post" "0" }}
+        {{ if .Params.tags }}
+            {{/* If `tags_include` is set, exclude posts with no tags. */}}
+            {{ if and ($page.Params.tags_include) (lt (len .Params.tags) 1) }}
+              {{ $.Scratch.Set "show_post" "0" }}
+            {{end}}
+            {{/* If `tags_exclude` is set, exclude posts. */}}
+            {{ range $key, $val := .Params.tags }}
+              {{ if in $page.Params.tags_exclude $val }}
+              {{ $.Scratch.Set "show_post" "0" }}
+            {{end}}
         {{end}}
 
-        {{/* If `tags_exclude` is set, exclude posts. */}}
-        {{ range $key, $val := .Params.tags }}
-          {{ if in $page.Params.tags_exclude $val }}
-          {{ $.Scratch.Set "show_post" "0" }}
-        {{end}}
       {{end}}
 
       {{ $show_post := $.Scratch.Get "show_post" }}


### PR DESCRIPTION
Fix the following  error when a post has no tags and the params tags_include is an empty collection on posts widget
```
ERROR 2017/10/25 08:52:07 Error while rendering "home": template: theme/index.html:1:3: executing "theme/index.html" at <partial "widget_page...>: error calling partial: template: theme/partials/widget_page.html:23:9: executing "theme/partials/widget_page.html" at <partial $widget $par...>: error calling partial: template: theme/partials/widgets/posts.html:62:55: executing "theme/partials/widgets/posts.html" at <len .Params.tags>: error calling len: len of untyped nil
```