### PR TITLE
Provide an OpenStreetMap-based alternative to Google Maps

### DIFF
--- a/data/sri.toml
+++ b/data/sri.toml
@@ -31,6 +31,9 @@
 [js.gmaps]
   version = "0.4.25"
   sri = "sha256-7vjlAeb8OaTrCXZkCNun9djzuB2owUsaO72kXaFDBJs="
+[js.leaflet]
+  version = "1.2.0"
+  sri = "sha512-lInM/apFSqyy1o6s89K4iQUKg6ppXEgsVxT35HbzUupEVRh2Eu9Wdl4tHj7dZO0s1uvplcYGmt3498TtHq+log=="
 
 # CSS
 
@@ -43,3 +46,6 @@
 [css.academicons]
   version = "1.8.1"
   sri = "sha512-NThgw3XKQ1absAahW6to7Ey42uycrVvfNfyjqcFNgCmOCQ5AR4AO0SiXrN+8ZtYeappp56lk1WtvjVmEa+VR6A=="
+[css.leaflet]
+  version = "1.2.0"
+  sri = "sha512-M2wvCLH6DSRazYeZRIm1JnYyh22purTM+FDB5CsyxtQJYeKq83arPe5wgbNmcFXGqiSH2XR8dT/fJISVA1r/zQ=="

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -71,7 +71,7 @@ defaultContentLanguageInSubdir = false
   longitude = "-122.1697"
 
   #   To use OpenStreetMap instead, leave google_maps_api_key empty, but fill in latitude and longitude. This will
-  #   enable a Leaflet widget using map tile directly from openstreetmap.org. Please have a look at their tile usage
+  #   enable a Leaflet widget using map tiles directly from openstreetmap.org. Please have a look at their tile usage
   #   policy, especially if you are running a high traffic site. In this case, please consider using tiles based on
   #   OpenStreetMap data provided by Mapbox (http://www.mapbox.com) instead. You will need an access token, that can be
   #   requested here: https://www.mapbox.com/studio/account/tokens

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -54,29 +54,28 @@ defaultContentLanguageInSubdir = false
   skype = "echo123"
   telegram = ""
 
-  # Enable Keybase in Contact section by entering your keybase.io username.
+  # Enable Keybase in Contact widget by entering your keybase.io username.
   keybase = ""
 
   # Diplay a logo in navigation bar rather than title (optional).
   #   To enable, place an image in `static/img/` and reference its filename below. To disable, set the value to "".
   logo = ""
 
-  # To show a location on a map in the contact widget, you need to enter your latitude, longitude and choose
-  # a map provider below. To use OpenStreetMap tiles, set "map = 3". Please have a look at their tile usage
-  # policy, especially if you are running a high traffic site. In this case, please consider using tiles based on
-  # OpenStreetMap data provided by Mapbox (http://www.mapbox.com) instead ("map = 2"). You will need an access token,
-  # that can be requested here:
-  #   https://www.mapbox.com/studio/account/tokens
-  # To use Google Maps, set "map = 1" and enter your API key that can be obtained here:
+  # Enable/disable map in Contact widget.
+  # To show your address on a map in the contact widget, you need to enter your latitude, longitude and choose
+  # a map provider below.
+  # To use Google Maps, set `map = 1` and enter your API key that can be obtained here:
   #   https://developers.google.com/maps/documentation/javascript/get-api-key
-  # To get your coordinates, right-click on Google Maps and choose "What's here". The coords will show up at the bottom.
-
-  # Map provider.
+  # To use OpenStreetMap tiles, set `map = 2`.
+  # To use OpenStreetMap on a high traffic site, set `map = 3` and enter your API key that can be obtained here:
+  #   https://www.mapbox.com/studio/account/tokens
+  # To get your coordinates, right-click on Google Maps and choose "What's here?". The coords will show up at the bottom.
+  #
+  # Map provider:
   #   0: No map
   #   1: Google Maps
-  #   2: OpenStreetMap (Mapbox)
-  #   3: OpenStreetMap (Mapnik)
-
+  #   2: OpenStreetMap (Mapnik)
+  #   3: OpenStreetMap (Mapbox)
   map = 0
   map_api_key = ""
   latitude = "37.4275"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -65,9 +65,18 @@ defaultContentLanguageInSubdir = false
   #   Get your API key: https://developers.google.com/maps/documentation/javascript/get-api-key
   #   Get your coords: Right-click place on Google Maps. Select 'What's here?'. At the bottom is a card with the coords.
   #   Disable Google Maps by clearing all three options to "".
+
   google_maps_api_key = ""
   latitude = "37.4275"
   longitude = "-122.1697"
+
+  #   To use OpenStreetMap instead, leave google_maps_api_key empty, but fill in latitude and longitude. This will
+  #   enable a Leaflet widget using map tile directly from openstreetmap.org. Please have a look at their tile usage
+  #   policy, especially if you are running a high traffic site. In this case, please consider using tiles based on
+  #   OpenStreetMap data provides by Mapbox (http://www.mapbox.com) instead. You will need an access token, that can be
+  #   requested here: https://www.mapbox.com/studio/account/tokens
+  leaflet_zoom = "13"
+  mapbox_token = ""
 
   # Date and time format (refer to Go's date format: http://fuckinggodateformat.com )
   #   Examples: "Mon, Jan 2, 2006" or "2006-01-02"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -75,7 +75,7 @@ defaultContentLanguageInSubdir = false
   #   policy, especially if you are running a high traffic site. In this case, please consider using tiles based on
   #   OpenStreetMap data provided by Mapbox (http://www.mapbox.com) instead. You will need an access token, that can be
   #   requested here: https://www.mapbox.com/studio/account/tokens
-  leaflet_zoom = "13"
+  zoom = "15"
   mapbox_token = ""
 
   # Date and time format (refer to Go's date format: http://fuckinggodateformat.com )

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -61,22 +61,27 @@ defaultContentLanguageInSubdir = false
   #   To enable, place an image in `static/img/` and reference its filename below. To disable, set the value to "".
   logo = ""
 
-  # Enable Google Maps by entering your API key, latitude, and longitude.
-  #   Get your API key: https://developers.google.com/maps/documentation/javascript/get-api-key
-  #   Get your coords: Right-click place on Google Maps. Select 'What's here?'. At the bottom is a card with the coords.
-  #   Disable Google Maps by clearing all three options to "".
+  # To show a location on a map in the contact widget, you need to enter your latitude, longitude and choose
+  # a map provider below. To use OpenStreetMap tiles, set "map = 3". Please have a look at their tile usage
+  # policy, especially if you are running a high traffic site. In this case, please consider using tiles based on
+  # OpenStreetMap data provided by Mapbox (http://www.mapbox.com) instead ("map = 2"). You will need an access token,
+  # that can be requested here:
+  #   https://www.mapbox.com/studio/account/tokens
+  # To use Google Maps, set "map = 1" and enter your API key that can be obtained here:
+  #   https://developers.google.com/maps/documentation/javascript/get-api-key
+  # To get your coordinates, right-click on Google Maps and choose "What's here". The coords will show up at the bottom.
 
-  google_maps_api_key = ""
+  # Map provider.
+  #   0: No map
+  #   1: Google Maps
+  #   2: OpenStreetMap (Mapbox)
+  #   3: OpenStreetMap (Mapnik)
+
+  map = 0
+  map_api_key = ""
   latitude = "37.4275"
   longitude = "-122.1697"
-
-  #   To use OpenStreetMap instead, leave google_maps_api_key empty, but fill in latitude and longitude. This will
-  #   enable a Leaflet widget using map tiles directly from openstreetmap.org. Please have a look at their tile usage
-  #   policy, especially if you are running a high traffic site. In this case, please consider using tiles based on
-  #   OpenStreetMap data provided by Mapbox (http://www.mapbox.com) instead. You will need an access token, that can be
-  #   requested here: https://www.mapbox.com/studio/account/tokens
-  zoom = "15"
-  mapbox_token = ""
+  zoom = 15
 
   # Date and time format (refer to Go's date format: http://fuckinggodateformat.com )
   #   Examples: "Mon, Jan 2, 2006" or "2006-01-02"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -73,7 +73,7 @@ defaultContentLanguageInSubdir = false
   #   To use OpenStreetMap instead, leave google_maps_api_key empty, but fill in latitude and longitude. This will
   #   enable a Leaflet widget using map tile directly from openstreetmap.org. Please have a look at their tile usage
   #   policy, especially if you are running a high traffic site. In this case, please consider using tiles based on
-  #   OpenStreetMap data provides by Mapbox (http://www.mapbox.com) instead. You will need an access token, that can be
+  #   OpenStreetMap data provided by Mapbox (http://www.mapbox.com) instead. You will need an access token, that can be
   #   requested here: https://www.mapbox.com/studio/account/tokens
   leaflet_zoom = "13"
   mapbox_token = ""

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,7 +5,7 @@
     <script id="dsq-count-scr" src="//{{ .Site.DisqusShortname }}.disqus.com/count.js" async></script>
     {{ end }}
 
-    {{ if .Site.Params.google_maps_api_key }}
+    {{ if eq .Site.Params.map "1" }}
     <script async defer src="//maps.googleapis.com/maps/api/js?key={{ .Site.Params.google_maps_api_key }}"></script>
     {{ end }}
 
@@ -14,9 +14,10 @@
     {{ printf "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/jquery.imagesloaded/%s/imagesloaded.pkgd.min.js\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" $js.imagesLoaded.version $js.imagesLoaded.sri | safeHTML }}
     {{ printf "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/%s/js/bootstrap.min.js\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" $js.bootstrap.version $js.bootstrap.sri | safeHTML }}
     {{ printf "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/jquery.isotope/%s/isotope.pkgd.min.js\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" $js.isotope.version $js.isotope.sri | safeHTML }}
-    {{ if .Site.Params.google_maps_api_key }}
+    {{ if eq .Site.Params.map 1 }}
     {{ printf "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/gmaps.js/%s/gmaps.min.js\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" $js.gmaps.version $js.gmaps.sri | safeHTML }}
-    {{ else }}
+    {{ end }}
+    {{ if or (eq .Site.Params.map 2) (eq .Site.Params.map 3) }}
     {{ printf "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/leaflet/%s/leaflet.js\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" $js.leaflet.version $js.leaflet.sri | safeHTML }}
     {{ end }}
     {{ else }}
@@ -24,9 +25,10 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery.imagesloaded/{{- $js.imagesLoaded.version -}}/imagesloaded.pkgd.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/{{- $js.bootstrap.version -}}/js/bootstrap.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery.isotope/{{- $js.isotope.version -}}/isotope.pkgd.min.js"></script>
-    {{ if .Site.Params.google_maps_api_key }}
+    {{ if eq .Site.Params.map 1 }}
     <script src="//cdnjs.cloudflare.com/ajax/libs/gmaps.js/{{- $js.gmaps.version -}}/gmaps.min.js"></script>
-    {{ else }}
+    {{ end }}
+    {{ if or (eq .Site.Params.map 2) (eq .Site.Params.map 3) }}
     <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/{{- $js.leaflet.version -}}/leaflet.js"></script>
     {{ end }}
     {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -16,6 +16,8 @@
     {{ printf "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/jquery.isotope/%s/isotope.pkgd.min.js\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" $js.isotope.version $js.isotope.sri | safeHTML }}
     {{ if .Site.Params.google_maps_api_key }}
     {{ printf "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/gmaps.js/%s/gmaps.min.js\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" $js.gmaps.version $js.gmaps.sri | safeHTML }}
+    {{ else }}
+    {{ printf "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/leaflet/%s/leaflet.js\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" $js.leaflet.version $js.leaflet.sri | safeHTML }}
     {{ end }}
     {{ else }}
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/{{- $js.jQuery.version -}}/jquery.min.js"></script>
@@ -24,6 +26,8 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery.isotope/{{- $js.isotope.version -}}/isotope.pkgd.min.js"></script>
     {{ if .Site.Params.google_maps_api_key }}
     <script src="//cdnjs.cloudflare.com/ajax/libs/gmaps.js/{{- $js.gmaps.version -}}/gmaps.min.js"></script>
+    {{ else }}
+    <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/{{- $js.leaflet.version -}}/leaflet.js"></script>
     {{ end }}
     {{ end }}
     <script src="{{ "/js/hugo-academic.js" | relURL }}"></script>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -6,7 +6,7 @@
     {{ end }}
 
     {{ if eq .Site.Params.map "1" }}
-    <script async defer src="//maps.googleapis.com/maps/api/js?key={{ .Site.Params.google_maps_api_key }}"></script>
+    <script async defer src="//maps.googleapis.com/maps/api/js?key={{ .Site.Params.map_api_key }}"></script>
     {{ end }}
 
     {{ if not .Site.Params.disable_sri }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,7 +5,7 @@
     <script id="dsq-count-scr" src="//{{ .Site.DisqusShortname }}.disqus.com/count.js" async></script>
     {{ end }}
 
-    {{ if eq .Site.Params.map "1" }}
+    {{ if eq .Site.Params.map 1 }}
     <script async defer src="//maps.googleapis.com/maps/api/js?key={{ .Site.Params.map_api_key }}"></script>
     {{ end }}
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -16,8 +16,7 @@
     {{ printf "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/jquery.isotope/%s/isotope.pkgd.min.js\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" $js.isotope.version $js.isotope.sri | safeHTML }}
     {{ if eq .Site.Params.map 1 }}
     {{ printf "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/gmaps.js/%s/gmaps.min.js\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" $js.gmaps.version $js.gmaps.sri | safeHTML }}
-    {{ end }}
-    {{ if or (eq .Site.Params.map 2) (eq .Site.Params.map 3) }}
+    {{ else if or (eq .Site.Params.map 2) (eq .Site.Params.map 3) }}
     {{ printf "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/leaflet/%s/leaflet.js\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" $js.leaflet.version $js.leaflet.sri | safeHTML }}
     {{ end }}
     {{ else }}
@@ -27,8 +26,7 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery.isotope/{{- $js.isotope.version -}}/isotope.pkgd.min.js"></script>
     {{ if eq .Site.Params.map 1 }}
     <script src="//cdnjs.cloudflare.com/ajax/libs/gmaps.js/{{- $js.gmaps.version -}}/gmaps.min.js"></script>
-    {{ end }}
-    {{ if or (eq .Site.Params.map 2) (eq .Site.Params.map 3) }}
+    {{ else if or (eq .Site.Params.map 2) (eq .Site.Params.map 3) }}
     <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/{{- $js.leaflet.version -}}/leaflet.js"></script>
     {{ end }}
     {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -31,12 +31,16 @@
   {{ printf "<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/%s/css/bootstrap.min.css\" integrity=\"%s\" crossorigin=\"anonymous\">" $sri.css.bootstrap.version $sri.css.bootstrap.sri | safeHTML }}
   {{ printf "<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/academicons/%s/css/academicons.min.css\" integrity=\"%s\" crossorigin=\"anonymous\">" $sri.css.academicons.version $sri.css.academicons.sri | safeHTML }}
   {{ printf "<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/%s/css/font-awesome.min.css\" integrity=\"%s\" crossorigin=\"anonymous\">" $sri.css.fontAwesome.version $sri.css.fontAwesome.sri | safeHTML }}
+  {{ if or (eq .Site.Params.map 2) (eq .Site.Params.map 3) }}
   {{ printf "<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/leaflet/%s/leaflet.css\" integrity=\"%s\" crossorigin=\"anonymous\">" $sri.css.leaflet.version $sri.css.leaflet.sri | safeHTML }}
+  {{ end }}
   {{ else }}
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/{{- $sri.css.bootstrap.version -}}/css/bootstrap.min.css">
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/academicons/{{- $sri.css.academicons.version -}}/css/academicons.min.css">
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/{{- $sri.css.fontAwesome.version -}}/css/font-awesome.min.css">
+  {{ if or (eq .Site.Params.map 2) (eq .Site.Params.map 3) }}
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/{{- $sri.css.leaflet.version -}}/leaflet.css">
+  {{ end }}
   {{ end }}
   {{/* We cannot use SRI with Google Fonts because the CSS is dynamically generated according to the user agent */}}
   {{- partial "css/parse_theme.css" . -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -31,10 +31,12 @@
   {{ printf "<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/%s/css/bootstrap.min.css\" integrity=\"%s\" crossorigin=\"anonymous\">" $sri.css.bootstrap.version $sri.css.bootstrap.sri | safeHTML }}
   {{ printf "<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/academicons/%s/css/academicons.min.css\" integrity=\"%s\" crossorigin=\"anonymous\">" $sri.css.academicons.version $sri.css.academicons.sri | safeHTML }}
   {{ printf "<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/%s/css/font-awesome.min.css\" integrity=\"%s\" crossorigin=\"anonymous\">" $sri.css.fontAwesome.version $sri.css.fontAwesome.sri | safeHTML }}
+  {{ printf "<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/leaflet/%s/leaflet.css\" integrity=\"%s\" crossorigin=\"anonymous\">" $sri.css.leaflet.version $sri.css.leaflet.sri | safeHTML }}
   {{ else }}
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/{{- $sri.css.bootstrap.version -}}/css/bootstrap.min.css">
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/academicons/{{- $sri.css.academicons.version -}}/css/academicons.min.css">
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/{{- $sri.css.fontAwesome.version -}}/css/font-awesome.min.css">
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/{{- $sri.css.leaflet.version -}}/leaflet.css">
   {{ end }}
   {{/* We cannot use SRI with Google Fonts because the CSS is dynamically generated according to the user agent */}}
   {{- partial "css/parse_theme.css" . -}}

--- a/layouts/partials/widgets/contact.html
+++ b/layouts/partials/widgets/contact.html
@@ -76,16 +76,17 @@
 
     {{ if and $.Site.Params.latitude $.Site.Params.longitude }}
     <div class="hidden">
-      {{ if $.Site.Params.google_maps_api_key }}
-      <input id="gmap-lat" value="{{ $.Site.Params.latitude }}" />
-      <input id="gmap-lng" value="{{ $.Site.Params.longitude }}" />
-      <input id="gmap-dir" value="{{ $.Site.Params.address }}" />
-      {{ else }}
-      <input id="leaflet-lat" value="{{ $.Site.Params.latitude }}" />
-      <input id="leaflet-lng" value="{{ $.Site.Params.longitude }}" />
-      <input id="leaflet-zoom" value="{{ $.Site.Params.zoom }}" />
-      <input id="leaflet-dir" value="{{ $.Site.Params.address }}" />
-      <input id="mapbox-token" value="{{ $.Site.Params.mapbox_token }}" />
+      {{ if eq $.Site.Params.map 1}}
+      <input id="gmap-lat" value="{{ $.Site.Params.latitude }}">
+      <input id="gmap-lng" value="{{ $.Site.Params.longitude }}">
+      <input id="gmap-dir" value="{{ $.Site.Params.address }}">
+      {{ end }}
+      {{ if or (eq $.Site.Params.map 2) (eq $.Site.Params.map 3) }}
+      <input id="leaflet-lat" value="{{ $.Site.Params.latitude }}">
+      <input id="leaflet-lng" value="{{ $.Site.Params.longitude }}">
+      <input id="leaflet-zoom" value="{{ $.Site.Params.zoom }}">
+      <input id="leaflet-dir" value="{{ $.Site.Params.address }}">
+      <input id="mapbox-token" value="{{ $.Site.Params.map_api_key }}">
       {{ end }}
     </div>
     <div id="map"></div>

--- a/layouts/partials/widgets/contact.html
+++ b/layouts/partials/widgets/contact.html
@@ -74,14 +74,13 @@
 
     </ul>
 
-    {{ if and $.Site.Params.latitude $.Site.Params.longitude }}
+    {{ if $.Site.Params.map }}
     <div class="hidden">
       {{ if eq $.Site.Params.map 1}}
       <input id="gmap-lat" value="{{ $.Site.Params.latitude }}">
       <input id="gmap-lng" value="{{ $.Site.Params.longitude }}">
       <input id="gmap-dir" value="{{ $.Site.Params.address }}">
-      {{ end }}
-      {{ if or (eq $.Site.Params.map 2) (eq $.Site.Params.map 3) }}
+      {{ else if or (eq $.Site.Params.map 2) (eq $.Site.Params.map 3) }}
       <input id="leaflet-lat" value="{{ $.Site.Params.latitude }}">
       <input id="leaflet-lng" value="{{ $.Site.Params.longitude }}">
       <input id="leaflet-zoom" value="{{ $.Site.Params.zoom }}">

--- a/layouts/partials/widgets/contact.html
+++ b/layouts/partials/widgets/contact.html
@@ -80,7 +80,7 @@
       <input id="map-lat" value="{{ $.Site.Params.latitude }}">
       <input id="map-lng" value="{{ $.Site.Params.longitude }}">
       <input id="map-dir" value="{{ $.Site.Params.address }}">
-      <input id="map-zoom" value="{{ $.Site.Params.zoom }}">
+      <input id="map-zoom" value="{{ $.Site.Params.zoom | default "15" }}">
       <input id="map-api-key" value="{{ $.Site.Params.map_api_key }}">
     </div>
     <div id="map"></div>

--- a/layouts/partials/widgets/contact.html
+++ b/layouts/partials/widgets/contact.html
@@ -76,9 +76,17 @@
 
     {{ if and $.Site.Params.latitude $.Site.Params.longitude }}
     <div class="hidden">
+      {{ if $.Site.Params.google_maps_api_key }}
       <input id="gmap-lat" value="{{ $.Site.Params.latitude }}" />
       <input id="gmap-lng" value="{{ $.Site.Params.longitude }}" />
       <input id="gmap-dir" value="{{ $.Site.Params.address }}" />
+      {{ else }}
+      <input id="leaflet-lat" value="{{ $.Site.Params.latitude }}" />
+      <input id="leaflet-lng" value="{{ $.Site.Params.longitude }}" />
+      <input id="leaflet-zoom" value="{{ $.Site.Params.zoom }}" />
+      <input id="leaflet-dir" value="{{ $.Site.Params.address }}" />
+      <input id="mapbox-token" value="{{ $.Site.Params.mapbox_token }}" />
+      {{ end }}
     </div>
     <div id="map"></div>
     {{ end }}

--- a/layouts/partials/widgets/contact.html
+++ b/layouts/partials/widgets/contact.html
@@ -76,17 +76,12 @@
 
     {{ if $.Site.Params.map }}
     <div class="hidden">
-      {{ if eq $.Site.Params.map 1}}
-      <input id="gmap-lat" value="{{ $.Site.Params.latitude }}">
-      <input id="gmap-lng" value="{{ $.Site.Params.longitude }}">
-      <input id="gmap-dir" value="{{ $.Site.Params.address }}">
-      {{ else if or (eq $.Site.Params.map 2) (eq $.Site.Params.map 3) }}
-      <input id="leaflet-lat" value="{{ $.Site.Params.latitude }}">
-      <input id="leaflet-lng" value="{{ $.Site.Params.longitude }}">
-      <input id="leaflet-zoom" value="{{ $.Site.Params.zoom }}">
-      <input id="leaflet-dir" value="{{ $.Site.Params.address }}">
-      <input id="mapbox-token" value="{{ $.Site.Params.map_api_key }}">
-      {{ end }}
+      <input id="map-provider" value="{{ $.Site.Params.map }}">
+      <input id="map-lat" value="{{ $.Site.Params.latitude }}">
+      <input id="map-lng" value="{{ $.Site.Params.longitude }}">
+      <input id="map-dir" value="{{ $.Site.Params.address }}">
+      <input id="map-zoom" value="{{ $.Site.Params.zoom }}">
+      <input id="map-api-key" value="{{ $.Site.Params.map_api_key }}">
     </div>
     <div id="map"></div>
     {{ end }}

--- a/static/js/hugo-academic.js
+++ b/static/js/hugo-academic.js
@@ -178,15 +178,17 @@
 
   function initMap () {
     if ($('#map').length) {
+      let lat = $('#map-lat').val();
+      let lng = $('#map-lng').val();
+      let zoom = $('#map-zoom').val();
+      let address = $('#map-dir').val();
+      
       if($('#gmap-lat').length) {
-        let lat = $('#gmap-lat').val();
-        let lng = $('#gmap-lng').val();
-        let address = $('#gmap-dir').val();
-
         let map = new GMaps({
           div: '#map',
           lat: lat,
           lng: lng,
+          zoom: zoom,
           zoomControl: true,
           zoomControlOpt: {
             style: 'SMALL',
@@ -210,11 +212,6 @@
           title: address
         })
       } else {
-          let lat = $('#leaflet-lat').val();
-          let lng = $('#leaflet-lng').val();
-          let zoom = $('#leaflet-zoom').val();
-          let address = $('#leaflet-dir').val();
-
           let map = new L.map('map').setView([lat, lng], zoom);
           if($('#mapbox-token').val().length) {
             let mapbox_token = $('#mapbox-token').val();

--- a/static/js/hugo-academic.js
+++ b/static/js/hugo-academic.js
@@ -215,7 +215,7 @@
         })
       } else {
           let map = new L.map('map').setView([lat, lng], zoom);
-          if ( api_key.length ) {
+          if ( map_provider == 3 && api_key.length ) {
             L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}', {
               attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
               maxZoom: 18,

--- a/static/js/hugo-academic.js
+++ b/static/js/hugo-academic.js
@@ -232,7 +232,7 @@
           }
           let marker = L.marker([lat, lng]).addTo(map);
           let url = lat + ',' + lng +'#map='+ zoom +'/'+ lat +'/'+ lng +'&layers=N';
-          marker.bindPopup(address + '<p><a href="https://www.openstreetmap.org/directions?engine=osrm_car&route='+ url +'">Routing via openstreetmap</a></p>');
+          marker.bindPopup(address + '<p><a href="https://www.openstreetmap.org/directions?engine=osrm_car&route='+ url +'">Routing via OpenStreetMap</a></p>');
       }
     }
   }

--- a/static/js/hugo-academic.js
+++ b/static/js/hugo-academic.js
@@ -181,7 +181,7 @@
       let map_provider = $('#map-provider').val();
       let lat = $('#map-lat').val();
       let lng = $('#map-lng').val();
-      let zoom = $('#map-zoom').val();
+      let zoom = parseInt($('#map-zoom').val());
       let address = $('#map-dir').val();
       let api_key = $('#map-api-key').val();
       

--- a/static/js/hugo-academic.js
+++ b/static/js/hugo-academic.js
@@ -173,41 +173,67 @@
   }
 
   /* ---------------------------------------------------------------------------
-  * Google maps.
+  * Google maps or OpenStreetMap via Leaflet.
   * --------------------------------------------------------------------------- */
 
   function initMap () {
     if ($('#map').length) {
-      let lat = $('#gmap-lat').val();
-      let lng = $('#gmap-lng').val();
-      let address = $('#gmap-dir').val();
+      if($('#gmap-lat').length) {
+        let lat = $('#gmap-lat').val();
+        let lng = $('#gmap-lng').val();
+        let address = $('#gmap-dir').val();
 
-      let map = new GMaps({
-        div: '#map',
-        lat: lat,
-        lng: lng,
-        zoomControl: true,
-        zoomControlOpt: {
-          style: 'SMALL',
-          position: 'TOP_LEFT'
-        },
-        panControl: false,
-        streetViewControl: false,
-        mapTypeControl: false,
-        overviewMapControl: false,
-        scrollwheel: true,
-        draggable: true
-      });
+        let map = new GMaps({
+          div: '#map',
+          lat: lat,
+          lng: lng,
+          zoomControl: true,
+          zoomControlOpt: {
+            style: 'SMALL',
+            position: 'TOP_LEFT'
+          },
+          panControl: false,
+          streetViewControl: false,
+          mapTypeControl: false,
+          overviewMapControl: false,
+          scrollwheel: true,
+          draggable: true
+        });
 
-      map.addMarker({
-        lat: lat,
-        lng: lng,
-        click: function (e) {
-          let url = 'https://www.google.com/maps/place/' + encodeURIComponent(address) + '/@' + lat + ',' + lng +'/';
-          window.open(url, '_blank')
-        },
-        title: address
-      })
+        map.addMarker({
+          lat: lat,
+          lng: lng,
+          click: function (e) {
+            let url = 'https://www.google.com/maps/place/' + encodeURIComponent(address) + '/@' + lat + ',' + lng +'/';
+            window.open(url, '_blank')
+          },
+          title: address
+        })
+      } else {
+          let lat = $('#leaflet-lat').val();
+          let lng = $('#leaflet-lng').val();
+          let zoom = $('#leaflet-zoom').val();
+          let address = $('#leaflet-dir').val();
+
+          let map = new L.map('map').setView([lat, lng], zoom);
+          if($('#mapbox-token').val().length) {
+            let mapbox_token = $('#mapbox-token').val();
+            L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}', {
+              attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
+              maxZoom: 18,
+              id: 'mapbox.streets',
+              accessToken: mapbox_token
+            }).addTo(map);
+          } else {
+            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+              maxZoom: 19,
+              attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+            }).addTo(map);
+          }
+          let marker = L.marker([lat, lng]).addTo(map);
+          let url = lat + ',' + lng +'#map='+ zoom +'/'+ lat +'/'+ lng +'&layers=N';
+          marker.bindPopup(address + '<p><a href="https://www.openstreetmap.org/directions?engine=osrm_car&route='+ url +'">Routing via openstreetmap</a></p>');
+      }
     }
   }
 

--- a/static/js/hugo-academic.js
+++ b/static/js/hugo-academic.js
@@ -173,17 +173,19 @@
   }
 
   /* ---------------------------------------------------------------------------
-  * Google maps or OpenStreetMap via Leaflet.
+  * Google Maps or OpenStreetMap via Leaflet.
   * --------------------------------------------------------------------------- */
 
   function initMap () {
     if ($('#map').length) {
+      let map_provider = $('#map-provider').val();
       let lat = $('#map-lat').val();
       let lng = $('#map-lng').val();
       let zoom = $('#map-zoom').val();
       let address = $('#map-dir').val();
+      let api_key = $('#map-api-key').val();
       
-      if($('#gmap-lat').length) {
+      if ( map_provider == 1 ) {
         let map = new GMaps({
           div: '#map',
           lat: lat,
@@ -213,13 +215,12 @@
         })
       } else {
           let map = new L.map('map').setView([lat, lng], zoom);
-          if($('#mapbox-token').val().length) {
-            let mapbox_token = $('#mapbox-token').val();
+          if ( api_key.length ) {
             L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}', {
               attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
               maxZoom: 18,
               id: 'mapbox.streets',
-              accessToken: mapbox_token
+              accessToken: api_key
             }).addTo(map);
           } else {
             L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {


### PR DESCRIPTION
This adds an OSM-based map as an alternative to Google Maps to the contact widget. It is activated by providing coordinates, but no gmap api key. Currently two tile sets are provided: The stock OSM tiles which are subject to the [OSM tile usage policy](https://operations.osmfoundation.org/policies/tiles/) and tiles provided by [Mapbox](http://www.mapbox.com) which are based off OSM data as well, but require an api key. The latter is useful for high traffic sites that may violate the OSM tile usage policy.

![screenshot_20171027_183434](https://user-images.githubusercontent.com/552653/32115031-8ef2c8c6-bb45-11e7-93ba-42e4831f895f.png)
