### PR TITLE
Fix project filter buttons

### DIFF
--- a/layouts/partials/widgets/projects.html
+++ b/layouts/partials/widgets/projects.html
@@ -15,7 +15,8 @@
     <span class="hidden default-project-filter">{{ (index $page.Params.filter ($filter_default)).tag }}</span>
     {{ end }}
 
-    {{ if and (($page.Params.filter) (gt (len $page.Params.filter) 1)) }}
+    {{ if isset $page.Params "filter" }}
+    {{ if gt (len $page.Params.filter) 1 }}
     <div class="project-toolbar">
       <div class="project-filters">
         <div class="btn-toolbar">
@@ -27,6 +28,7 @@
         </div>
       </div>
     </div>
+    {{ end }}
     {{ end }}
 
     {{ if eq $page.Params.view 0 }}


### PR DESCRIPTION
Fixes a bug introduced in the fix of #306, where the project filter buttons are shown even when there is only one filter avaliable.

The clause `if and (($page.Params.filter) (gt (len $page.Params.filter) 1))` returns `true` under all circumstances, as does `and ((true) (false))`, due to the parentheses.
To check the length of `filters` only if the parameter `$page.Params.filter` is set, nested `if`-clauses are required, since the templating system does not provide short-circuit evaluation of boolean expressions.