### PR TITLE
Add hreflang to page header

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -9,6 +9,12 @@
   {{ .Hugo.Generator }}
   {{ with .Site.Params.name }}<meta name="author" content="{{ . }}">{{ end }}
   {{ with .Site.Params.role }}<meta name="description" content="{{ . }}">{{ end }}
+  
+  {{ if .IsTranslated }}
+  {{ range .Translations }}
+  <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}"/>
+  {{ end}}
+  {{ end }}
 
   {{ $sri := .Site.Data.sri }}
   {{/* Default to enabling highlighting, but allow the user to override it in .Params or .Site.Params.

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -10,10 +10,8 @@
   {{ with .Site.Params.name }}<meta name="author" content="{{ . }}">{{ end }}
   {{ with .Site.Params.role }}<meta name="description" content="{{ . }}">{{ end }}
   
-  {{ if .IsTranslated }}
   {{ range .Translations }}
   <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}">
-  {{ end }}
   {{ end }}
   <link rel="alternate" hreflang="{{ .Site.LanguageCode | default "en-us" }}" href="{{ .Permalink }}">
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -12,10 +12,10 @@
   
   {{ if .IsTranslated }}
   {{ range .Translations }}
-  <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}"/>
-  {{ end}}
+  <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}">
   {{ end }}
-  <link rel="alternate" hreflang="{{ .Site.LanguageCode | default "en-us" }}" href="{{ .Permalink }}"/>
+  {{ end }}
+  <link rel="alternate" hreflang="{{ .Site.LanguageCode | default "en-us" }}" href="{{ .Permalink }}">
 
   {{ $sri := .Site.Data.sri }}
   {{/* Default to enabling highlighting, but allow the user to override it in .Params or .Site.Params.

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -15,6 +15,7 @@
   <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}"/>
   {{ end}}
   {{ end }}
+  <link rel="alternate" hreflang="{{ .Site.LanguageCode | default "en-us" }}" href="{{ .Permalink }}"/>
 
   {{ $sri := .Site.Data.sri }}
   {{/* Default to enabling highlighting, but allow the user to override it in .Params or .Site.Params.


### PR DESCRIPTION
This adds an link-rel-hreflang to the page header for every available translation.
This enables modern browsers to automatically choose the right language version of any translated page (without visiting the sitemap).