### PR TITLE
Making Abstracts Optional

### DIFF
--- a/layouts/publication/single.html
+++ b/layouts/publication/single.html
@@ -25,7 +25,7 @@
     {{ if .Params.abstract }}
     <h3>{{ i18n "abstract" }}</h3>
     <p class="pub-abstract" itemprop="text">{{ .Params.abstract | markdownify }}</p>
-    {{end}}
+    {{ end }}
 
     {{ if (.Params.publication_types) and (ne (index .Params.publication_types 0) "0") }}
     <div class="row">

--- a/layouts/publication/single.html
+++ b/layouts/publication/single.html
@@ -22,8 +22,10 @@
     <img src="{{ "/img/" | relURL }}{{ .Params.image }}" class="pub-banner" itemprop="image">
     {{end}}
 
+    {{ if .Params.abstract }}
     <h3>{{ i18n "abstract" }}</h3>
     <p class="pub-abstract" itemprop="text">{{ .Params.abstract | markdownify }}</p>
+    {{end}}
 
     {{ if (.Params.publication_types) and (ne (index .Params.publication_types 0) "0") }}
     <div class="row">


### PR DESCRIPTION
The simple idea behind this PR is that there is no point in showing the abstract header if there is no actual abstract. It therefore makes the abstract optional. Particularly new users who have already some publications might benefit from this. It simplifies the setup of a nice looking site while allowing for adding abstracts later on. 

@gcushen Please take a look.