### PR TITLE
Set the correct MicroData for blog-posts listed on the first page

### DIFF
--- a/layouts/partials/article_metadata.html
+++ b/layouts/partials/article_metadata.html
@@ -10,10 +10,7 @@
       {{ $.Lastmod.Format $.Site.Params.date_format }}
     </time>
   </span>
-  <span itemscope itemprop="author" itemtype="http://schema.org/Person">
-    <meta itemprop="name" content="{{ $.Site.Params.name }}">
-  </span>
-  <span itemscope itemprop="publisher" itemtype="http://schema.org/Person">
+  <span itemscope itemprop="author publisher" itemtype="http://schema.org/Person">
     <meta itemprop="name" content="{{ $.Site.Params.name }}">
   </span>
 

--- a/layouts/partials/article_metadata.html
+++ b/layouts/partials/article_metadata.html
@@ -6,9 +6,15 @@
     {{ if ne $.Params.Lastmod $.Params.Date }}
         {{ i18n "last_updated" }}
     {{ end }}
-    <time datetime="{{ $.Date }}" itemprop="datePublished">
+    <time datetime="{{ $.Date }}" itemprop="datePublished dateModified">
       {{ $.Lastmod.Format $.Site.Params.date_format }}
     </time>
+  </span>
+  <span itemscope itemprop="author" itemtype="http://schema.org/Person">
+    <meta itemprop="name" content="{{ $.Site.Params.name }}">
+  </span>
+  <span itemscope itemprop="publisher" itemtype="http://schema.org/Person">
+    <meta itemprop="name" content="{{ $.Site.Params.name }}">
   </span>
 
   {{ if ne $.Site.Params.reading_time false }}

--- a/layouts/partials/post_li.html
+++ b/layouts/partials/post_li.html
@@ -7,8 +7,7 @@
     <img src="{{ "/img/" | relURL }}{{ $post.Params.header.image }}" class="article-banner" itemprop="image">
   </a>
   {{end}}
-  <meta itemprop="headline" content="{{ $post.Title }}">
-  <h3 class="article-title" itemprop="name">
+  <h3 class="article-title" itemprop="headline">
     <a href="{{ $post.Permalink }}" itemprop="url">{{ $post.Title }}</a>
   </h3>
   {{ partial "article_metadata" (dict "content" $post "is_list" 1) }}

--- a/layouts/partials/post_li.html
+++ b/layouts/partials/post_li.html
@@ -1,6 +1,6 @@
 {{ $post := .post }}
 
-<div class="article-list-item" itemscope itemprop="blogPost">
+<div class="article-list-item" itemscope itemprop="blogPost" itemtype="http://schema.org/BlogPosting">
   {{ $preview := $post.Params.header.preview | default true }}
   {{ if and $post.Params.header.image $preview }}
   <a href="{{ $post.Permalink }}">

--- a/layouts/partials/post_li.html
+++ b/layouts/partials/post_li.html
@@ -7,6 +7,11 @@
     <img src="{{ "/img/" | relURL }}{{ $post.Params.header.image }}" class="article-banner" itemprop="image">
   </a>
   {{end}}
+  {{ if $post.Params.header.caption }}
+  <meta itemprop="headline" content="{{ $post.Params.header.caption }}">
+  {{ else }}
+  <meta itemprop="headline" content="{{ $post.Title }}">
+  {{ end }}
   <h3 class="article-title" itemprop="name">
     <a href="{{ $post.Permalink }}" itemprop="url">{{ $post.Title }}</a>
   </h3>
@@ -20,7 +25,7 @@
     {{ $post.Content }}
     {{ end }}
   </div>
-  <p class="read-more">
+  <p class="read-more" itemprop="mainEntityOfPage">
     <a href="{{ $post.Permalink }}" class="btn btn-primary btn-outline">
       {{ i18n "continue_reading" }}
     </a>

--- a/layouts/partials/post_li.html
+++ b/layouts/partials/post_li.html
@@ -7,11 +7,7 @@
     <img src="{{ "/img/" | relURL }}{{ $post.Params.header.image }}" class="article-banner" itemprop="image">
   </a>
   {{end}}
-  {{ if $post.Params.header.caption }}
-  <meta itemprop="headline" content="{{ $post.Params.header.caption }}">
-  {{ else }}
   <meta itemprop="headline" content="{{ $post.Title }}">
-  {{ end }}
   <h3 class="article-title" itemprop="name">
     <a href="{{ $post.Permalink }}" itemprop="url">{{ $post.Title }}</a>
   </h3>


### PR DESCRIPTION
This commit will enable search engines to properly see each blog entry listed on the first page, a small but vital change.