### PR TITLE
Make project widget easier to reuse

### DIFF
--- a/exampleSite/content/home/projects.md
+++ b/exampleSite/content/home/projects.md
@@ -2,6 +2,7 @@
 # Projects widget.
 # This widget displays all projects from `content/project/`.
 widget = "projects"
+folder = "project"
 active = true
 date = "2016-04-20T00:00:00"
 
@@ -27,7 +28,7 @@ filter_default = 0
 [[filter]]
   name = "All"
   tag = "*"
-  
+
 [[filter]]
   name = "Deep Learning"
   tag = ".deep-learning"

--- a/exampleSite/content/home/projects.md
+++ b/exampleSite/content/home/projects.md
@@ -1,8 +1,6 @@
 +++
 # Projects widget.
-# This widget displays all projects from `content/project/`.
 widget = "projects"
-folder = "project"
 active = true
 date = "2016-04-20T00:00:00"
 
@@ -11,6 +9,11 @@ subtitle = ""
 
 # Order that this section will appear in.
 weight = 50
+
+# Content.
+# Display content from the following folder.
+# For example, `folder = "project"` displays content from `content/project/`.
+folder = "project"
 
 # View.
 # Customize how projects are displayed.

--- a/layouts/partials/widgets/projects.html
+++ b/layouts/partials/widgets/projects.html
@@ -34,7 +34,7 @@
     {{ if eq $page.Params.view 0 }}
 
     <div class="row isotope projects-container js-layout-row">
-        {{ range where $.Site.RegularPages "Type" "project" }}
+        {{ range where $.Site.RegularPages "Type" ($page.Params.folder | default "project") }}
         <div class="col-md-12 project-item isotope-item {{ delimit .Params.tags " " }}" itemscope itemtype="http://schema.org/CreativeWork">
           <i class="fa fa-files-o pub-icon" aria-hidden="true"></i>
 
@@ -56,7 +56,7 @@
 
     <div class="row isotope projects-container js-layout-masonry">
 
-      {{ range $project := where $.Site.RegularPages "Type" "project" }}
+      {{ range $project := where $.Site.RegularPages "Type" ($page.Params.folder | default "project") }}
       {{ $.Scratch.Set "project_url" $project.Permalink }}
       {{ $.Scratch.Set "target" "" }}
       {{ if $project.Params.external_link }}


### PR DESCRIPTION
### Purpose

*project* widget is a very nice feature and is reusable. However, there are still many limitations and inconvenience related to the project widget. See #100, #274, #396.

This PR makes project widget more usable and is compatible with older codes.

If someone wants to reuse project widget, e.g. adding a people section, he can just copy `content/home/projects.md` to `content/home/people.md` and `content/projects/` to `content/people/` and modify modify some frontmatter in markdown files.

