### PR TITLE
fix the error when calling slicestr to slice out-of-range bounds

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -51,12 +51,15 @@
         </li>
 
         {{ else }}
-
-        {{ if eq "http" (slicestr .URL 0 4) }}
-          {{ $.Scratch.Set "target" " target=\"_blank\" rel=\"noopener\"" }}
-        {{ else }}
-          {{ $.Scratch.Set "target" "" }}
-        {{ end }}
+          {{ if gt (len .URL) 4 }}
+            {{ if eq "http" (slicestr .URL 0 4) }}
+              {{ $.Scratch.Set "target" " target=\"_blank\" rel=\"noopener\"" }}
+            {{ else }}
+              {{ $.Scratch.Set "target" "" }}
+            {{ end }}
+          {{ else }}
+            {{ $.Scratch.Set "target" "" }}
+          {{ end }}
 
         <li class="nav-item">
           <a href="{{ .URL | relLangURL }}"{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -51,15 +51,14 @@
         </li>
 
         {{ else }}
-          {{ if gt (len .URL) 4 }}
-            {{ if eq "http" (slicestr .URL 0 4) }}
-              {{ $.Scratch.Set "target" " target=\"_blank\" rel=\"noopener\"" }}
-            {{ else }}
-              {{ $.Scratch.Set "target" "" }}
-            {{ end }}
-          {{ else }}
-            {{ $.Scratch.Set "target" "" }}
+        
+        {{/* Set target for link. */}}
+        {{ $.Scratch.Set "target" "" }}
+        {{ if gt (len .URL) 4 }}
+          {{ if eq "http" (slicestr .URL 0 4) }}
+            {{ $.Scratch.Set "target" " target=\"_blank\" rel=\"noopener\"" }}
           {{ end }}
+        {{ end }}
 
         <li class="nav-item">
           <a href="{{ .URL | relLangURL }}"{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}{{ ($.Scratch.Get "target") | safeHTMLAttr }}>


### PR DESCRIPTION
### Purpose

When trying to add an entry to the navigation menu, the following error happened if the URL is less than 4 characters, in my case, "#cv"

> error  calling partial: template: partials/navbar.html:63:52: executing "partials/navbar.html" at <slicestr .URL 0 4>: error calling slicestr: slice bounds out of range

this is due to

`{{ if eq "http" (slicestr .URL 0 4) }}`

and can be fixed by checking the length of the URL.


By the way, I was trying to make it

`{{ if and (gt (len .URL) 4) (eq "http" (slicestr .URL 0 4)) }}`

but it seems that short-circuit evaluation is not supported.