### PR TITLE
use relLangURL for project links

### DIFF
--- a/layouts/partials/publication_links.html
+++ b/layouts/partials/publication_links.html
@@ -31,7 +31,7 @@
 {{ end }}
 {{ if $.Params.projects }}
 {{ range $.Params.projects }}
-<a class="btn btn-primary btn-outline{{ if $is_list }} btn-xs{{end}}" href="{{ printf "project/%s/" . | relURL }}">
+<a class="btn btn-primary btn-outline{{ if $is_list }} btn-xs{{end}}" href="{{ printf "project/%s/" . | relLangURL }}">
   {{ i18n "btn_project" }}
 </a>
 {{ end }}

--- a/layouts/partials/talk_links.html
+++ b/layouts/partials/talk_links.html
@@ -22,7 +22,7 @@
 </a>
 {{ end }}
 {{ range $.Params.projects }}
-<a class="btn btn-primary btn-outline{{ if $is_list }} btn-xs{{end}}" href="{{ printf "project/%s/" . | relURL }}">
+<a class="btn btn-primary btn-outline{{ if $is_list }} btn-xs{{end}}" href="{{ printf "project/%s/" . | relLangURL }}">
   {{ i18n "btn_project" }}
 </a>
 {{ end }}


### PR DESCRIPTION
### Purpose

Fix a bug related to links to `projects` for multi-language sites.

For example, for a Chinese website, the link should be `zh/project/myproject/` not `project/myproject/`.