### PR TITLE
Add option for custom site title and page title seperator

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -53,6 +53,9 @@ defaultContentLanguageInSubdir = false
   name = "Lena Smith"
   role = "Professor of Artificial Intelligence"
 
+  # Seperator between site title and page titles
+  title_sep = " | "
+
   # Organizations/Affiliations.
   #   Separate multiple entries with a comma, using the form: `[ {name="Org1", url=""}, {name="Org2", url=""} ]`.
   organizations = [ { name = "Stanford University", url = "" } ]

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -126,7 +126,7 @@
 
   {{ partial "head_custom" . }}
 
-  <title>{{ if not .IsHome }}{{ .Title }}{{ .Site.Params.Title_sep }}{{ end }}{{ .Site.Title }}</title>
+  <title>{{ if not .IsHome }}{{ .Title }}{{ .Site.Params.Title_sep }}{{ .Site.Title}}{{ else }}{{ .Site.Params.description }}{{ .Site.Params.Title_sep }}{{ .Site.Title }}{{ end }}</title>
 
 </head>
 <body id="top" data-spy="scroll" data-target="{{ if or .IsHome .Params.widgets }}#navbar-main{{ else }}#toc{{ end }}" data-offset="71" {{ if not ($scr.Get "light") }}class="dark"{{ end }}>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -126,7 +126,7 @@
 
   {{ partial "head_custom" . }}
 
-  <title>{{ if not .IsHome }}{{ .Title }} | {{ end }}{{ .Site.Title }}</title>
+  <title>{{ if not .IsHome }}{{ .Title }}{{ .Site.Params.Title_sep }}{{ end }}{{ .Site.Title }}</title>
 
 </head>
 <body id="top" data-spy="scroll" data-target="{{ if or .IsHome .Params.widgets }}#navbar-main{{ else }}#toc{{ end }}" data-offset="71" {{ if not ($scr.Get "light") }}class="dark"{{ end }}>


### PR DESCRIPTION
### Purpose

Added option for a custom title separator. Instead of using the default " | ", allows user the option to use their own title separator from the config file.

### Screenshots

NA

### Documentation

NA
