### PR TITLE
Added twitter to contact info

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -65,6 +65,7 @@ defaultContentLanguageInSubdir = false
   phone = "888 888 88 88"
   skype = "echo123"
   telegram = ""
+  twitter = "GoHugoIO"
 
   # Enable Keybase in Contact widget by entering your keybase.io username.
   keybase = ""

--- a/layouts/partials/widgets/contact.html
+++ b/layouts/partials/widgets/contact.html
@@ -66,6 +66,15 @@
         </span>
       </li>
       {{ end }}
+      
+      {{ with $.Site.Params.twitter }}
+      <li>
+        <i class="fa-li fa fa-twitter fa-2x" aria-hidden="true"></i>
+        <span>
+        {{- if $autolink }}<a href="https://www.twitter.com/{{ . }}" target="_blank">@{{ . }}</a>{{ else }}@{{ . }}{{ end -}}
+        </span>
+      </li>
+      {{ end }}
 
       {{ with $.Site.Params.address }}
       <li>


### PR DESCRIPTION
### Purpose

I wanted to add my twitter information to the contact page of my hugo website.

### Screenshots

See e.g., https://andrewfowlie.github.io/#contact

### Documentation

I don't see explicit documentation for the contact widget at https://sourcethemes.com/academic/docs/get-started/, so I haven't added a corresponding PR there.
