### PR TITLE
Support external header images.

### DIFF
--- a/layouts/partials/header_image.html
+++ b/layouts/partials/header_image.html
@@ -1,6 +1,12 @@
 {{ if .Params.header.image }}
 <div class="article-header">
-  <img src="{{ "/img/" | relURL }}{{ .Params.header.image }}" class="article-banner" itemprop="image">
+  {{ $img_src := urls.Parse $.Params.header.image }}
+  {{ if $img_src.Scheme }}
+    <img src="{{ .Params.header.image }}" class="article-banner" itemprop="image">
+  {{ else }}
+    <img src="{{ "/img/" | relURL }}{{ .Params.header.image }}" class="article-banner" itemprop="image">
+  {{ end }}
+  
   {{ with .Params.header.caption }}<span class="article-header-caption">{{ . | markdownify | emojify }}</span>{{ end }}
 </div>
 {{end}}

--- a/layouts/partials/header_image.html
+++ b/layouts/partials/header_image.html
@@ -1,12 +1,12 @@
 {{ if .Params.header.image }}
 <div class="article-header">
-  {{ $img_src := urls.Parse $.Params.header.image }}
+  {{ $img_src := urls.Parse .Params.header.image }}
   {{ if $img_src.Scheme }}
     <img src="{{ .Params.header.image }}" class="article-banner" itemprop="image">
   {{ else }}
     <img src="{{ "/img/" | relURL }}{{ .Params.header.image }}" class="article-banner" itemprop="image">
   {{ end }}
-  
+
   {{ with .Params.header.caption }}<span class="article-header-caption">{{ . | markdownify | emojify }}</span>{{ end }}
 </div>
 {{end}}

--- a/layouts/partials/post_li.html
+++ b/layouts/partials/post_li.html
@@ -6,7 +6,12 @@
   {{ $preview := $post.Params.header.preview | default true }}
   {{ if and $post.Params.header.image $preview }}
   <a href="{{ $post.Permalink }}">
-    <img src="{{ "/img/" | relURL }}{{ $post.Params.header.image }}" class="article-banner" itemprop="image">
+      {{ $img_src := urls.Parse $post.Params.header.image }}
+      {{ if $img_src.Scheme }}
+        <img src="{{ $post.Params.header.image }}" class="article-banner" itemprop="image">
+      {{ else }}
+        <img src="{{ "/img/" | relURL }}{{ $post.Params.header.image }}" class="article-banner" itemprop="image">
+      {{ end }}
   </a>
   {{end}}
   <h3 class="article-title" itemprop="headline">

--- a/layouts/partials/post_li.html
+++ b/layouts/partials/post_li.html
@@ -6,12 +6,12 @@
   {{ $preview := $post.Params.header.preview | default true }}
   {{ if and $post.Params.header.image $preview }}
   <a href="{{ $post.Permalink }}">
-      {{ $img_src := urls.Parse $post.Params.header.image }}
-      {{ if $img_src.Scheme }}
-        <img src="{{ $post.Params.header.image }}" class="article-banner" itemprop="image">
-      {{ else }}
-        <img src="{{ "/img/" | relURL }}{{ $post.Params.header.image }}" class="article-banner" itemprop="image">
-      {{ end }}
+    {{ $img_src := urls.Parse $post.Params.header.image }}
+    {{ if $img_src.Scheme }}
+      <img src="{{ $post.Params.header.image }}" class="article-banner" itemprop="image">
+    {{ else }}
+      <img src="{{ "/img/" | relURL }}{{ $post.Params.header.image }}" class="article-banner" itemprop="image">
+    {{ end }}
   </a>
   {{end}}
   <h3 class="article-title" itemprop="headline">

--- a/layouts/partials/publication_li_detailed.html
+++ b/layouts/partials/publication_li_detailed.html
@@ -8,7 +8,12 @@
   {{ if .Scratch.Get "image" }}
   <div>
     <a href="{{ .Permalink }}">
-      <img src="{{ "/img/" | relURL }}{{ .Scratch.Get "image" }}" class="pub-banner" itemprop="image">
+      {{ $img_src := urls.Parse .Scratch.Get "image" }}
+      {{ if $img_src.Scheme }}
+        <img src="{{ .Scratch.Get "image" }}" class="article-banner" itemprop="image">
+      {{ else }}
+        <img src="{{ "/img/" | relURL }}{{ .Scratch.Get "image" }}" class="article-banner" itemprop="image">
+      {{ end }}      
     </a>
   </div>
   {{ end }}

--- a/layouts/partials/talk_li_detailed.html
+++ b/layouts/partials/talk_li_detailed.html
@@ -8,7 +8,12 @@
   {{ if .Scratch.Get "image" }}
   <div>
     <a href="{{ .Permalink }}">
-      <img src="{{ "/img/" | relURL }}{{ .Scratch.Get "image" }}" class="pub-banner" itemprop="image">
+      {{ $img_src := urls.Parse .Scratch.Get "image" }}
+      {{ if $img_src.Scheme }}
+        <img src="{{ .Scratch.Get "image" }}" class="article-banner" itemprop="image">
+      {{ else }}
+        <img src="{{ "/img/" | relURL }}{{ .Scratch.Get "image" }}" class="article-banner" itemprop="image">
+      {{ end }} 
     </a>
   </div>
   {{ end }}


### PR DESCRIPTION
### Purpose

Previous implementation hard-coded an "img/" prefix to the header image URL. This means posts cannot use images from an external source.

This first parses the URL and checks if it has a http/https prefix. If it does, we know it's an absolute URL, so we don't add any prefixes.

Otherwise it's a relative URL, and we append the "img/" prefix as it did before.

### Screenshots

none

### Documentation

Note that both local (in `img/` dir) and external images are supported.