### PR TITLE
center social icons when there is more than one line

### DIFF
--- a/layouts/partials/css/academic.css
+++ b/layouts/partials/css/academic.css
@@ -469,6 +469,7 @@ a[data-fancybox] img {
   display: inline-flex;
   flex-direction: row;
   flex-wrap: wrap;
+  justify-content: center;
   list-style: none;
   padding: 0;
   margin-top: 30px;


### PR DESCRIPTION
### Purpose

center social icons when there is more than one line

### Screenshots
before:
![before](https://user-images.githubusercontent.com/5676729/37727899-32e80b02-2d39-11e8-8a9c-63de55abeb3b.png)

after:
![after](https://user-images.githubusercontent.com/5676729/37727905-354ba1a6-2d39-11e8-9be9-fadb6d575ed7.png)