### PR TITLE
Set default if no value is set for variables which require that

### DIFF
--- a/layouts/partials/article_metadata.html
+++ b/layouts/partials/article_metadata.html
@@ -7,7 +7,7 @@
         {{ i18n "last_updated" }}
     {{ end }}
     <time datetime="{{ $.Date }}" itemprop="datePublished dateModified">
-      {{ $.Lastmod.Format $.Site.Params.date_format }}
+      {{ $.Lastmod.Format ($.Site.Params.date_format | default "Jan 2, 2006") }}
     </time>
   </span>
   <span itemscope itemprop="author publisher" itemtype="http://schema.org/Person">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -106,9 +106,11 @@
   <link rel="canonical" href="{{ .Permalink }}">
 
   <meta property="twitter:card" content="summary_large_image">
+  {{ if isset $.Site.Params "social" }}
   {{ range where $.Site.Params.social ".icon" "twitter" }}
   <meta property="twitter:site" content="@{{ replaceRE "^//twitter.com/([^/]+)" "$1" .link }}">
   <meta property="twitter:creator" content="@{{ replaceRE "^//twitter.com/([^/]+)" "$1" .link  }}">
+  {{ end }}
   {{ end }}
   <meta property="og:site_name" content="{{ .Site.Title }}">
   <meta property="og:url" content="{{ .Permalink }}">

--- a/layouts/partials/talk_li_detailed.html
+++ b/layouts/partials/talk_li_detailed.html
@@ -24,7 +24,7 @@
 
   <div class="talk-metadata" itemprop="startDate">
     {{ $date := .Params.time_start | default .Date }}
-    {{ (time $date).Format $.Site.Params.date_format }}
+    {{ (time $date).Format ($.Site.Params.date_format | default "Jan 2, 2006") }}
     {{ if $.Site.Params.talks.time }}
       {{ (time $date).Format ($.Site.Params.time_format | default "3:04 PM") }}
       {{ with .Params.time_end }}

--- a/layouts/partials/talk_li_simple.html
+++ b/layouts/partials/talk_li_simple.html
@@ -3,7 +3,7 @@
   <span itemprop="name"><a href="{{ .Permalink }}">{{ .Title }}</a></span>
   <div itemprop="startDate">
     {{ $date := .Params.time_start | default .Date }}
-    {{ (time $date).Format $.Site.Params.date_format }}
+    {{ (time $date).Format ($.Site.Params.date_format | default "Jan 2, 2006") }}
     {{ if $.Site.Params.talks.time }}
       {{ (time $date).Format ($.Site.Params.time_format | default "3:04 PM") }}
     {{ end }}

--- a/layouts/talk/single.html
+++ b/layouts/talk/single.html
@@ -32,7 +32,7 @@
           <div class="col-xs-12 col-sm-3 pub-row-heading">{{ i18n "date" }}</div>
           <div class="col-xs-12 col-sm-9" itemprop="datePublished">
             {{ $date := .Params.time_start | default .Date }}
-            {{ (time $date).Format $.Site.Params.date_format }}
+            {{ (time $date).Format ($.Site.Params.date_format | default "Jan 2, 2006") }}
             <div class="talk-time">
               {{ if $.Site.Params.talks.time }}
                 {{ (time $date).Format ($.Site.Params.time_format | default "3:04 PM") }}


### PR DESCRIPTION
Fix #491 - site will be generated even with empty `config.toml`.