### PR TITLE
WIP: Support for Prism syntax highlighter

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -39,26 +39,44 @@
 
     <!-- Code highlighting -->
     {{ if $.Scratch.Get "highlight_enabled" }}
-      {{ $v := $js.highlight.version }}
-      {{ if not .Site.Params.disable_sri }}
-      {{ printf "<script src=\"//cdnjs.cloudflare.com/ajax/libs/highlight.js/%s/highlight.min.js\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" $v $js.highlight.sri | safeHTML }}
-      {{ else }}
-      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/{{ $v }}/highlight.min.js"></script>
-      {{ end }}
 
-      {{ range .Site.Params.highlight_languages }}
-      <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/{{ $v }}/languages/{{ . }}.min.js"></script>
-      {{ end }}
+      {{ if eq ($.Scratch.Get "highlight_engine") "highlight.js"}}
 
-      {{ range .Params.highlight_languages }}
-      {{/* Do not double-include languages that are in both .Site.Params and .Params.
-           If Hugo ever grows a "union" function for set union, this range clause can be merged with the one above. */}}
-        {{ if not (in $.Site.Params.highlight_languages .) }}
+        {{ $v := $js.highlight.version }}
+        {{ if not .Site.Params.disable_sri }}
+        {{ printf "<script src=\"//cdnjs.cloudflare.com/ajax/libs/highlight.js/%s/highlight.min.js\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" $v $js.highlight.sri | safeHTML }}
+        {{ else }}
+        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/{{ $v }}/highlight.min.js"></script>
+        {{ end }}
+
+        {{ range .Site.Params.highlight_languages }}
         <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/{{ $v }}/languages/{{ . }}.min.js"></script>
         {{ end }}
+
+        {{ range .Params.highlight_languages }}
+        {{/* Do not double-include languages that are in both .Site.Params and .Params.
+            If Hugo ever grows a "union" function for set union, this range clause can be merged with the one above. */}}
+          {{ if not (in $.Site.Params.highlight_languages .) }}
+          <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/{{ $v }}/languages/{{ . }}.min.js"></script>
+          {{ end }}
+        {{ end }}
+
+        <script>hljs.initHighlightingOnLoad();</script>
+
+      {{ else if eq ($.Scratch.Get "highlight_engine") "prism"}}
+
+        <script src="//cdnjs.cloudflare.com/ajax/libs/prism/1.14.0/prism.min.js"></script>
+
+        {{ range .Site.Params.highlight_languages }}
+
+          {{ if not (in $.Params.highlight_languages .) }}
+            <script src="//cdnjs.cloudflare.com/ajax/libs/prism/1.14.0/components/prism-{{ . }}.min.js"></script>
+          {{ end }}
+
+        {{ end }}
+
       {{ end }}
 
-      <script>hljs.initHighlightingOnLoad();</script>
     {{ end }}
 
     <!-- LaTeX math rendering -->

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -39,18 +39,41 @@
   {{ else if isset .Site.Params "highlight" }}
     {{ $scr.Set "highlight_enabled" .Site.Params.highlight }}
   {{ end }}
-  {{ if $scr.Get "highlight_enabled" }}
-    {{ $v := $sri.js.highlight.version }}
-    {{ with .Site.Params.highlight_style }}
-    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/{{ $v }}/styles/{{ . }}.min.css">
-    {{ else }}
-      {{ if eq ($scr.Get "light") true }}
-        <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/{{ $v }}/styles/github.min.css">
-      {{ else }}
-        <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/{{ $v }}/styles/dracula.min.css">
-      {{ end }}
-    {{ end }}
+  
+  {{ $scr.Set "highlight_engine" "highlight.js" }}
+  {{ if isset .Params "highlight_engine" }}
+    {{ $scr.Set "highlight_engine" .Params.highlight_engine }}
+  {{ else if isset .Site.Params "highlight_engine" }}
+    {{ $scr.Set "highlight_engine" .Site.Params.highlight_engine }}
   {{ end }}
+  
+  {{ if $scr.Get "highlight_enabled" }}
+    
+    {{ if eq ($scr.Get "highlight_engine") "highlight.js"}}
+  
+      {{ $v := $sri.js.highlight.version }}
+        {{ with .Site.Params.highlight_style }}
+        <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/{{ $v }}/styles/{{ . }}.min.css">
+      {{ else }}
+        {{ if eq ($scr.Get "light") true }}
+          <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/{{ $v }}/styles/github.min.css">
+        {{ else }}
+          <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/{{ $v }}/styles/dracula.min.css">
+        {{ end }}
+      {{ end }}
+      
+    {{ else if eq ($scr.Get "highlight_engine") "prism"}}
+    
+      {{ if eq ($scr.Get "light") true }}
+        <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/prism/1.14.0/themes/prism.min.css">
+      {{ else }}
+        <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/prism/1.14.0/themes/prism-dark.min.css">
+      {{ end }}
+    
+    {{ end }}
+    
+  {{ end }}
+
   {{ if not .Site.Params.disable_sri }}
   {{ printf "<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/%s/css/bootstrap.min.css\" integrity=\"%s\" crossorigin=\"anonymous\">" $sri.css.bootstrap.version $sri.css.bootstrap.sri | safeHTML }}
   {{ printf "<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/academicons/%s/css/academicons.min.css\" integrity=\"%s\" crossorigin=\"anonymous\">" $sri.css.academicons.version $sri.css.academicons.sri | safeHTML }}


### PR DESCRIPTION
### Purpose

While highlight.js is an established project it appears that it is no longer actively maintained.
Furthermore, I had to use syntax highlighting for MATLAB which I feel highlight.js does not adequately support.
So I switched to Prism which comes closer to covering my needs and I am contributing the changes back to the theme.
In this PR I tried not to break existing functionality, so I included a new parameter `highlight_engine`.
It can take values `highlight.js` and `prism`, with the default set to `highlight.js`.
If there is interest in this we can work on the `sri` and `version` variables which I did not yet implement for `prism`.

### Screenshots
This is how the default formatting looks for MATLAB in conjunction with the pre-existing `academic.css`.

![screenshot from 2018-04-13 14-30-00](https://user-images.githubusercontent.com/1205023/38735790-2c25f63c-3f2a-11e8-9fd2-c30df0b3c9c9.png)

### Documentation

>If this is an enhancement, add a link here to the corresponding pull request on https://github.com/sourcethemes/academic-www or describe the documentation changes necessary.

If there is interest in this I would be happy to contribute documentation as well.

### Notes

For some reason I had to switch between `.Site.Params.highlight_languages` and `.Params.highlight_languages` in header.html:70 and header.html:72 in comparison to what we have in the highlight.js section above that. Highlight languages are under `[params]` in config.toml, as I believe is the default, so I would need some enlightenment on this. Would it cause any problems anyway if we leave it like that?

 