### PR TITLE
Updated academicon version to support lattes icon.

### DIFF
--- a/data/sri.toml
+++ b/data/sri.toml
@@ -47,8 +47,8 @@
   version = "4.7.0"
   sri = "sha512-SfTiTlX6kk+qitfevl/7LibUOeJWlt9rbyDn92a1DqWOw9vWG2MFoays0sgObmWazO5BQPiFucnnEAjpAB+/Sw=="
 [css.academicons]
-  version = "1.8.1"
-  sri = "sha512-NThgw3XKQ1absAahW6to7Ey42uycrVvfNfyjqcFNgCmOCQ5AR4AO0SiXrN+8ZtYeappp56lk1WtvjVmEa+VR6A=="
+  version = "1.8.6"
+  sri = "sha256-uFVgMKfistnJAfoCUQigIl+JfUaP47GrRKjf6CTPVmw="
 [css.leaflet]
   version = "1.2.0"
   sri = "sha512-M2wvCLH6DSRazYeZRIm1JnYyh22purTM+FDB5CsyxtQJYeKq83arPe5wgbNmcFXGqiSH2XR8dT/fJISVA1r/zQ=="


### PR DESCRIPTION
### Purpose

The sole purpose is to update the academicons version to one that have [Lattes](http://lattes.cnpq.br/) as a social option. [Lattes](http://lattes.cnpq.br/) is a platform widely used by brazilian academics to share curriculums.
