### PR TITLE
talk: All metadata on 1 line (list simple)

### DIFF
--- a/layouts/partials/talk_li_simple.html
+++ b/layouts/partials/talk_li_simple.html
@@ -1,19 +1,26 @@
 <div class="pub-list-item" style="margin-bottom: 1rem" itemscope itemtype="http://schema.org/Event">
   <i class="fa fa-comment-o pub-icon" aria-hidden="true"></i>
   <span itemprop="name"><a href="{{ .Permalink }}">{{ .Title }}</a></span>
-  <div itemprop="startDate">
-    {{ $date := .Params.time_start | default .Date }}
-    {{ (time $date).Format $.Site.Params.date_format }}
-    {{ if $.Site.Params.talks.time }}
-      {{ (time $date).Format ($.Site.Params.time_format | default "3:04 PM") }}
-    {{ end }}
-  </div>
   <div class="talk-metadata">
     {{ if .Params.event_short }}
-        {{ .Params.event_short | markdownify }}
+      {{ .Params.event_short | markdownify }}
     {{ else if .Params.event }}
-            {{ .Params.event | markdownify }}
+      {{ .Params.event | markdownify }}
     {{ end }}
+    {{ if .Params.location }}
+      {{ if or .Params.event_short .Params.event }} — {{ end }}
+      <span itemprop="location">
+        {{ .Params.location }},
+      </span>
+    {{ end }}
+
+    <span itemprop="startDate">
+      {{ $date := .Params.time_start | default .Date }}
+      {{ (time $date).Format $.Site.Params.date_format }}
+      {{ if $.Site.Params.talks.time }}
+        {{ (time $date).Format ($.Site.Params.time_format | default "3:04 PM") }}
+      {{ end }}
+    </span>
   </div>
   <div class="talk-links">
     {{ partial "talk_links" (dict "content" . "is_list" 1) }}


### PR DESCRIPTION
### Purpose

This is a proposal to have all "talk metadata" (i.e., `event`, `location`, `date`) on one single line under the title, rather than currently in two lines, on the `talk_li_simple` widget. This behaviour seems logical and more consistent with the presentation of publications in the equivalent widget.

It changes:

- Location is added (not present before)
- Order is changed towards: `Event — Location, DateTime`
- Separators are added (`—` systematic after event and `,` between location and date IF there is a location)

### Screenshots

![2018 04 30 capture 080](https://user-images.githubusercontent.com/4708459/39434604-55ace1c4-4c99-11e8-92fc-3a6f4bfb87b6.png)
