### PR TITLE
Updated the cookie consent banner so it changes according to the theme

### DIFF
--- a/layouts/partials/cookie_consent.html
+++ b/layouts/partials/cookie_consent.html
@@ -1,4 +1,5 @@
 {{ if .Site.Params.privacy_pack }}
+{{ $scr := .Scratch }}
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.css">
 <script src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.js"></script>
 <script>
@@ -6,12 +7,15 @@
     window.cookieconsent.initialise({
       "palette": {
         "popup": {
-          "background": "#000"
+          "background": "{{ $scr.Get "primary" }}",
+          "text": "{{ $scr.Get "background" }}"
         },
         "button": {
-          "background": "#f1d600"
+          "background": "{{ $scr.Get "background" }}",
+          "text": "{{ $scr.Get "primary" }}"
         }
       },
+      "theme": "classic",
       "content": {
         "message": {{ i18n "cookie_message" | default "This website uses cookies to ensure you get the best experience on our website." }},
         "dismiss": {{ i18n "cookie_dismiss" | default "Got it!" }},


### PR DESCRIPTION
### Purpose

This changes the partial `cookie_consent.html` so that the cookie consent banner has a more appropriate theme, i.e., so that it agrees with each of the academic themes. 

### Screenshots

![screenshot from 2018-05-01 19-29-29](https://user-images.githubusercontent.com/635220/39484978-b30bf63c-4d77-11e8-8f76-597c545175f8.png)
![screenshot from 2018-05-01 19-30-02](https://user-images.githubusercontent.com/635220/39484979-b32851d8-4d77-11e8-9997-6e689bd357e6.png)
![screenshot from 2018-05-01 19-30-33](https://user-images.githubusercontent.com/635220/39484980-b3410ebc-4d77-11e8-8419-f6f9b5bfe47d.png)
![screenshot from 2018-05-01 19-30-49](https://user-images.githubusercontent.com/635220/39484981-b35c6d38-4d77-11e8-8e94-48f527b7c599.png)
![screenshot from 2018-05-01 19-31-13](https://user-images.githubusercontent.com/635220/39484982-b379f0b0-4d77-11e8-9dc0-edbb83e69aa3.png)
![screenshot from 2018-05-01 19-31-26](https://user-images.githubusercontent.com/635220/39484983-b393512c-4d77-11e8-9338-093e89e6bd72.png)

