### PR TITLE
projects: Fix list of publications/talks

### DIFF
--- a/layouts/project/single.html
+++ b/layouts/project/single.html
@@ -35,7 +35,7 @@
       {{ $pubs_len := len $items }}
       {{ if ge $pubs_len 1 }}
         <h2>{{ (i18n "publications") }}</h2>
-        {{ range $items }}
+        {{ range $items.ByDate.Reverse }}
           {{ if eq $page.Site.Params.projects.publication_format 1 }}
             {{ partial "publication_li_detailed" . }}
           {{ else if eq $page.Site.Params.projects.publication_format 2 }}
@@ -49,11 +49,11 @@
       {{ end }}
 
       {{ $items := where (where .Site.RegularPages "Type" "talk") ".Params.projects" "intersect" (slice $project) }}
-      {{ $items := $items | union (where (where .Site.RegularPages "Type" "publication") ".Params.url_project" $project_path) }}
+      {{ $items := $items | union (where (where .Site.RegularPages "Type" "talk") ".Params.url_project" $project_path) }}
       {{ $talks_len := len $items }}
       {{ if ge $talks_len 1 }}
         <h2>{{ (i18n "talks") }}</h2>
-        {{ range $items }}
+        {{ range sort $items ".Params.time_start" "desc" }}
           {{ partial "talk_li_simple" . }}
         {{ end }}
       {{ end }}

--- a/layouts/project/single.html
+++ b/layouts/project/single.html
@@ -35,7 +35,7 @@
       {{ $pubs_len := len $items }}
       {{ if ge $pubs_len 1 }}
         <h2>{{ (i18n "publications") }}</h2>
-        {{ range $items.ByDate.Reverse }}
+        {{ range $items }}
           {{ if eq $page.Site.Params.projects.publication_format 1 }}
             {{ partial "publication_li_detailed" . }}
           {{ else if eq $page.Site.Params.projects.publication_format 2 }}


### PR DESCRIPTION
- Sort list of publications by Date (as in homepage widget) (previously: was sorted by Title I think)
- Sort list of talks by Time_Start (as in homepage widget) (previously: was sorted by Title I think)
- Fix bug that made publications be duplicated under "talks" when there was no talk in a project