### PR TITLE
tags: Style changed to 'label'

### DIFF
--- a/layouts/partials/tags.html
+++ b/layouts/partials/tags.html
@@ -1,9 +1,9 @@
 {{ if isset $.Params "tags" }}
 {{ $tagsLen := len $.Params.tags }}
 {{ if gt $tagsLen 0 }}
-<div class="article-tags">
+<div class="article-tags text-right">
   {{ range $k, $v := $.Params.tags }}
-  <a class="btn btn-primary btn-outline" href="{{ ($.Site.GetPage "taxonomyTerm" "tags" .).Permalink }}">{{ . }}</a>
+  <a class="label label-default" href="{{ ($.Site.GetPage "taxonomyTerm" "tags" .).Permalink }}">{{ . }}</a>
   {{ end }}
 </div>
 {{ end }}


### PR DESCRIPTION
- Style of tags changed to 'label label-default' to avoid confusion with links buttons
- Group of tags aligned to the right (at least in project page)

### Purpose

The objective is mainly to avoid confusion between **tags** and **links buttons** (currently, same style) among others in a project or publication page.

I think it is be better to align tags to the right (indicating they are of minor importance, as an additional information), but that might be removed from this PR if it does not seem relevant.

### Screenshots

![2018 05 23 capture 103](https://user-images.githubusercontent.com/4708459/40418497-dc4e9ccc-5e82-11e8-825b-0a12909c77bb.png)

