### PR TITLE
Fix date published and date modified in structured data

### DIFF
--- a/layouts/partials/article_metadata.html
+++ b/layouts/partials/article_metadata.html
@@ -6,7 +6,8 @@
     {{ if ne $.Params.Lastmod $.Params.Date }}
         {{ i18n "last_updated" }}
     {{ end }}
-    <time datetime="{{ $.Date }}" itemprop="datePublished dateModified">
+    <time datetime="{{ $.Params.Date }}" itemprop="datePublished">
+    <time datetime="{{ $.Params.LastMod }}" itemprop="dateModified">
       {{ $.Lastmod.Format $.Site.Params.date_format }}
     </time>
   </span>

--- a/layouts/partials/article_metadata.html
+++ b/layouts/partials/article_metadata.html
@@ -6,7 +6,7 @@
     {{ if ne $.Params.Lastmod $.Params.Date }}
         {{ i18n "last_updated" }}
     {{ end }}
-    <time datetime="{{ $.Params.Date }}" itemprop="datePublished">
+    <meta content="{{ $.Params.Date }}" itemprop="datePublished">
     <time datetime="{{ $.Params.LastMod }}" itemprop="dateModified">
       {{ $.Lastmod.Format $.Site.Params.date_format }}
     </time>


### PR DESCRIPTION
Signed-off-by: Prateek Kumar <prateek@prateekkumar.in>

### Purpose

For posts, in the structured data, datePublished and dateModified may be different. Previously both datePublished and dateModified were set to same value `$.Date`. In this commit, these fields are set to `$.Params.Date` and `$.Params.LastMod` respectively.