### PR TITLE
Adds Open Access bling to selected publications

### DIFF
--- a/archetypes/publication.md
+++ b/archetypes/publication.md
@@ -42,6 +42,12 @@ projects = []
 #   Set `tags = []` for no tags, or use the form `tags = ["A Tag", "Another Tag"]` for one or more tags.
 tags = []
 
+# License information (optional)
+#   Setting `openaccess = true` will add an Open Access logo beside each publication.
+openaccess = false
+#  If you would like to specify the open license used, you may do so, otherwise, "Open Access" will appear on the publication details page.
+# license = ""
+
 # Links (optional).
 url_pdf = ""
 url_preprint = ""

--- a/exampleSite/content/publication/clothing-search.md
+++ b/exampleSite/content/publication/clothing-search.md
@@ -42,6 +42,12 @@ projects = ["example-external-project.md"]
 #   Set `tags = []` for no tags, or use the form `tags = ["A Tag", "Another Tag"]` for one or more tags.
 tags = []
 
+# License information (optional)
+#   Setting `openaccess = true` will add an Open Access logo beside each publication.
+openaccess = false
+#  If you would like to specify the open license used, you may do so, otherwise, "Open Access" will appear on the publication details page.
+# license = ""
+
 # Links (optional).
 url_pdf = "http://eprints.soton.ac.uk/352095/1/Cushen-IMV2013.pdf"
 url_preprint = "http://eprints.soton.ac.uk/352095/1/Cushen-IMV2013.pdf"

--- a/exampleSite/content/publication/person-re-identification.md
+++ b/exampleSite/content/publication/person-re-identification.md
@@ -42,6 +42,12 @@ projects = []
 #   Set `tags = []` for no tags, or use the form `tags = ["A Tag", "Another Tag"]` for one or more tags.
 tags = []
 
+# License information (optional)
+#   Setting `openaccess = true` will add an Open Access logo beside each publication.
+openaccess = false
+#  If you would like to specify the open license used, you may do so, otherwise, "Open Access" will appear on the publication details page.
+# license = ""
+
 # Links (optional).
 url_pdf = "http://arxiv.org/pdf/1512.04133v1"
 url_preprint = ""

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -113,6 +113,12 @@
 - id: location
   translation: Location
 
+- id: openaccess
+  translation: Open Access
+
+- id: license
+  translation: License
+
 # Filtering
 
 - id: filter_by_type

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -113,6 +113,12 @@
 - id: location
   translation: Localización
 
+- id: openaccess
+  translation: Acceso Abierto
+
+- id: license
+  translation: Licencia
+
 # Filtering
 
 - id: filter_by_type

--- a/layouts/partials/publication_li_apa.html
+++ b/layouts/partials/publication_li_apa.html
@@ -1,5 +1,8 @@
 <div class="pub-list-item" style="margin-bottom: 1rem" itemscope itemtype="http://schema.org/CreativeWork">
   <i class="fa fa-file-text-o pub-icon" aria-hidden="true"></i>
+  {{ if .Params.openaccess }}
+    <i class="ai ai-open-access small-icon"></i>
+  {{end}}
   <span itemprop="author">
     {{ with .Params.authors }}
       {{- delimit . ", " | markdownify -}}

--- a/layouts/partials/publication_li_detailed.html
+++ b/layouts/partials/publication_li_detailed.html
@@ -19,6 +19,9 @@
   {{ end }}
 
   <h3 class="article-title" itemprop="name">
+    {{ if .Params.openaccess }}
+      <i class="ai ai-open-access small-icon"></i>
+    {{end}}
     <a href="{{ .Permalink }}" itemprop="url">{{ .Title }}</a>
   </h3>
 

--- a/layouts/partials/publication_li_mla.html
+++ b/layouts/partials/publication_li_mla.html
@@ -1,5 +1,8 @@
 <div class="pub-list-item" style="margin-bottom: 1rem" itemscope itemtype="http://schema.org/CreativeWork">
   <i class="fa fa-file-text-o pub-icon" aria-hidden="true"></i>
+  {{ if .Params.openaccess }}
+    <i class="ai ai-open-access small-icon"></i>
+  {{end}}
   <span itemprop="author">
     {{ with .Params.authors }}
       {{- delimit . ", " | markdownify -}}

--- a/layouts/partials/publication_li_simple.html
+++ b/layouts/partials/publication_li_simple.html
@@ -1,5 +1,8 @@
 <div class="pub-list-item" style="margin-bottom: 1rem" itemscope itemtype="http://schema.org/CreativeWork">
   <i class="fa fa-file-text-o pub-icon" aria-hidden="true"></i>
+  {{ if .Params.openaccess }}
+    <i class="ai ai-open-access small-icon"></i>
+  {{end}}
   <a href="{{ .Permalink }}" itemprop="name">{{ .Title }}</a>
   <div itemprop="author">
     {{ with .Params.authors }}

--- a/layouts/publication/single.html
+++ b/layouts/publication/single.html
@@ -58,6 +58,24 @@
     <div class="visible-xs space-below"></div>
     {{ end }}
 
+    {{ if .Params.openaccess }}
+    <div class="row">
+      <div class="col-sm-1"></div>
+      <div class="col-sm-10">
+        <div class="row">
+          <div class="col-xs-12 col-sm-3 pub-row-heading">{{ i18n "license" }}</div>
+          {{ if .Params.license }}
+            <div class="col-xs-12 col-sm-9">{{ .Params.license | markdownify }}</div>
+          {{ else }}
+            <div class="col-xs-12 col-sm-9">{{ i18n "openaccess" }}</div>
+          {{ end }}
+        </div>
+      </div>
+      <div class="col-sm-1"></div>
+    </div>
+    <div class="visible-xs space-below"></div>
+    {{ end }}
+
     <div class="row">
       <div class="col-sm-1"></div>
       <div class="col-sm-10">


### PR DESCRIPTION
### Purpose

This PR adds an Open Access logo beside publications that are Open Access. Also allows the author to specify a license if a specific license was used. 

### Screenshots

##### Publication List, APA (MLA and simple are similar)

![screenshot_20180718_172103](https://user-images.githubusercontent.com/870746/42908863-12260a8e-8ab0-11e8-9b91-ae4e49b1dd37.png)

##### Publication List, detailed

![screenshot_20180718_172408](https://user-images.githubusercontent.com/870746/42908857-0dc7a524-8ab0-11e8-8c89-6cb25516155a.png)

##### Publication page, specific license

![screenshot_20180718_172130](https://user-images.githubusercontent.com/870746/42908864-123cf6f4-8ab0-11e8-9384-163adc03cba0.png)

##### Publication page, no license specified

![screenshot_20180718_172146](https://user-images.githubusercontent.com/870746/42908856-0db22ec4-8ab0-11e8-9b20-f580d8405654.png)

### Documentation

I don't think that any big changes are required. I've documented the example site archetypes and example publications. 






