### PR TITLE
Add Short Courses Section

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -185,6 +185,11 @@ enableGitInfo = false
     'Book section'  # 6
   ]
 
+  # Configuration of Short Courses page.
+  [params.shortcourses]
+    # Show talk time?
+    date_format = "2006"
+    
   # Configuration of talk pages.
   [params.talks]
     # Show talk time?

--- a/exampleSite/content/home/shortcourses.md
+++ b/exampleSite/content/home/shortcourses.md
@@ -1,0 +1,17 @@
++++
+# Recent and Upcoming Talks widget.
+widget = "shortcourses"
+active = true
+date = 2016-04-20T00:00:00
+
+title = "Short Courses"
+subtitle = ""
+
+# Order that this section will appear in.
+weight = 55
+
+# Number of talks to list.
+count = 10
+
++++
+

--- a/exampleSite/content/shortcourses/_index.md
+++ b/exampleSite/content/shortcourses/_index.md
@@ -1,0 +1,11 @@
++++
+title = "Short Courses"
+date = 2017-01-01T00:00:00
+math = false
+highlight = false
+
+# Optional featured image (relative to `static/img/` folder).
+[header]
+image = ""
+caption = ""
++++

--- a/exampleSite/content/shortcourses/example-shortcourse.md
+++ b/exampleSite/content/shortcourses/example-shortcourse.md
@@ -1,0 +1,25 @@
++++
+date = 2017-01-01T00:00:00  # Schedule page publish date.
+
+title = "Introduction to JavaScript"
+time_start = 2030-06-01
+commitment = "8 weeks, 3-5 hours a week."
+institution = "Codeacademy"
+institution_url = "https://example.org"
+type_course = "Online Course"
+
+# Does the content use math formatting?
+math = true
+
+# Does the content use source code highlighting?
+highlight = true
+
+# Featured image
+# Place your image in the `static/img/` folder and reference its filename below, e.g. `image = "example.jpg"`.
+[header]
+image = "headers/bubbles-wide.jpg"
+caption = "My caption :smile:"
+
++++
+
+Describe here what you learnt.

--- a/exampleSite/content/shortcourses/example-shortcourse.md
+++ b/exampleSite/content/shortcourses/example-shortcourse.md
@@ -1,10 +1,10 @@
 +++
 date = 2017-01-01T00:00:00  # Schedule page publish date.
 
-title = "Introduction to JavaScript"
+title = "Game Theory"
 time_start = 2030-06-01
 commitment = "8 weeks, 3-5 hours a week."
-institution = "Codeacademy"
+institution = "Stanford University"
 institution_url = "https://example.org"
 type_course = "Online Course"
 

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -74,6 +74,17 @@
 
 - id: location
   translation: Ort
+  
+# Short Courses details
+
+- id: institution
+  translation: Institution
+  
+- id: type_course
+  translation: Art
+  
+- id: commitment
+  translation: Verpflichtung
 
 # Filtering
 

--- a/i18n/el.yaml
+++ b/i18n/el.yaml
@@ -109,6 +109,17 @@
 
 - id: location
   translation: Τοποθεσία
+  
+# Short Courses details
+
+- id: institution
+  translation: Ιδρυμα
+  
+- id: type_course
+  translation: Είδος μαθήματος
+  
+- id: commitment
+  translation: δέσμευση
 
 # Filtering
 

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -112,6 +112,17 @@
 
 - id: location
   translation: Location
+  
+# Short Courses details
+
+- id: institution
+  translation: Institution
+  
+- id: type_course
+  translation: Type
+  
+- id: commitment
+  translation: Commitment
 
 # Filtering
 

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -112,6 +112,17 @@
 
 - id: location
   translation: Localización
+  
+# Short Courses details
+
+- id: institution
+  translation: Institución
+  
+- id: type_course
+  translation: Tipo de curso
+  
+- id: commitment
+  translation: Compromiso
 
 # Filtering
 

--- a/i18n/eu.yaml
+++ b/i18n/eu.yaml
@@ -74,6 +74,17 @@
 
 - id: location
   translation: Kokalekua
+  
+# Short Courses details
+
+- id: institution
+  translation: Erakunde
+  
+- id: type_course
+  translation: Ikastaro mota
+  
+- id: commitment
+  translation: Konpromisoa
 
 # Filtering
 

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -112,6 +112,17 @@
 
 - id: location
   translation: Lieu
+  
+# Short Courses details
+
+- id: institution
+  translation: Institution
+  
+- id: type_course
+  translation: Type de cours
+  
+- id: commitment
+  translation: Engagement
 
 # Filtering
 

--- a/i18n/id.yaml
+++ b/i18n/id.yaml
@@ -109,6 +109,17 @@
 
 - id: location
   translation: Lokasi
+  
+# Short Courses details
+
+- id: institution
+  translation: Lembaga
+  
+- id: type_course
+  translation: Jenis saja
+  
+- id: commitment
+  translation: Komitmen
 
 # Filtering
 

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -74,6 +74,17 @@
 
 - id: location
   translation: Luogo
+  
+# Short Courses details
+
+- id: institution
+  translation: Istituzione
+  
+- id: type_course
+  translation: Tipo di corso
+  
+- id: commitment
+  translation: Impegno
 
 # Filtering
 

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -74,6 +74,17 @@
 
 - id: location
   translation: 장소
+  
+# Short Courses details
+
+- id: institution
+  translation: 제도
+  
+- id: type_course
+  translation: 코스 종류
+  
+- id: commitment
+  translation: 헌신
 
 # Filtering
 

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -74,6 +74,17 @@
 
 - id: location
   translation: Locatie
+  
+# Short Courses details
+
+- id: institution
+  translation: Instelling
+  
+- id: type_course
+  translation: Type natuurlijk
+  
+- id: commitment
+  translation: Inzet
 
 # Filtering
 

--- a/i18n/pl.yaml
+++ b/i18n/pl.yaml
@@ -88,6 +88,17 @@
 
 - id: location
   translation: Miejsce
+  
+# Short Courses details
+
+- id: institution
+  translation: Instytucja
+  
+- id: type_course
+  translation: Rodzaj kursu
+  
+- id: commitment
+  translation: Zaangażowanie
 
 # Filtering
 

--- a/i18n/pt.yaml
+++ b/i18n/pt.yaml
@@ -74,6 +74,17 @@
 
 - id: location
   translation: Local
+  
+# Short Courses details
+
+- id: institution
+  translation: Instituição
+  
+- id: type_course
+  translation: Tipo de Curso
+  
+- id: commitment
+  translation: Dedicação
 
 # Filtering
 

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -74,6 +74,17 @@
 
 - id: location
   translation: Место
+  
+# Short Courses details
+
+- id: institution
+  translation: учреждение
+  
+- id: type_course
+  translation: Тип курса
+  
+- id: commitment
+  translation: обязательство
 
 # Filtering
 

--- a/i18n/tr.yaml
+++ b/i18n/tr.yaml
@@ -74,6 +74,17 @@
 
 - id: location
   translation: Adres
+  
+# Short Courses details
+
+- id: institution
+  translation: Kurum
+  
+- id: type_course
+  translation: Kurs türü
+  
+- id: commitment
+  translation: Taahhüt
 
 # Filtering
 

--- a/i18n/vi.yaml
+++ b/i18n/vi.yaml
@@ -109,6 +109,17 @@
 
 - id: location
   translation: Địa Điểm
+  
+# Short Courses details
+
+- id: institution
+  translation: Tổ chức giáo dục
+  
+- id: type_course
+  translation: Loại khóa học
+  
+- id: commitment
+  translation: Cam kết
 
 # Filtering
 

--- a/i18n/zh.yaml
+++ b/i18n/zh.yaml
@@ -112,6 +112,17 @@
 
 - id: location
   translation: 位置
+  
+# Short Courses details
+
+- id: institution
+  translation: 机构
+  
+- id: type_course
+  translation: 课程类型
+  
+- id: commitment
+  translation: 承诺
 
 # Filtering
 

--- a/layouts/partials/css/academic.css
+++ b/layouts/partials/css/academic.css
@@ -1586,3 +1586,30 @@ body.dark {
   background: rgb(40, 42, 54);
   color: rgb(248, 248, 242);
 }
+
+/*************************************************
+ *  Short Courses
+ **************************************************/
+
+#container-shortcourses {
+  display: block;
+  position: relative;
+  overflow: hidden;
+}
+
+.shortcourses-metadata {
+  color: #4b4f56;
+  font-size: 1rem;
+}
+
+@media (min-width: 768px) {
+   .shortcourses-date {
+      text-align: right; 
+  }
+}
+
+@media (min-width: 768px) {
+   .shortcourses-type {
+      text-align: right; 
+  }
+}

--- a/layouts/partials/widgets/shortcourses.html
+++ b/layouts/partials/widgets/shortcourses.html
@@ -1,0 +1,35 @@
+{{ $ := .root }}
+{{ $page := .page }}
+{{ $shortcourses_len := len (where $.Site.RegularPages "Type" "shortcourses") }}
+
+<!-- Short Courses widget -->
+<div class="container-shortcourses">
+    <div class="row">
+        <div class="col-xs-12 col-md-4 section-heading">
+            <h1>{{ with $page.Title }}{{ . | markdownify }}{{ end }}</h1>
+      {{ with $page.Params.subtitle }}<p>{{ . | markdownify }}</p>{{ end }}
+        </div>
+        <div class="col-xs-12 col-md-8">
+          {{ with $page.Content }}<p>{{ . | markdownify }}</p>{{ end }}
+          {{ range first $page.Params.count (sort (where $.Site.RegularPages "Type" "shortcourses") ".Params.time_start" "desc") }}
+            <div class="shortcourses-metadata" style="margin-bottom: 1rem">
+              <div class="row">
+                  <div class="col-xs-12 col-sm-6">
+                    <span itemprop="name"><a href="{{ .Permalink }}">{{ .Title }}</a></span>
+                  </div>
+                  <div class="col-xs-12 col-sm-6 shortcourses-date">
+                   {{ $date := .Params.time_start | default .Date }}
+                   {{ (time $date).Format $.Site.Params.shortcourses.date_format }}
+                  </div>
+                  <div class="col-xs-12 col-sm-6">
+                    {{ .Params.institution | markdownify }}
+                  </div>
+                  <div class="col-xs-12 col-sm-6 shortcourses-type">
+                    {{ .Params.type_course }}
+                  </div>
+              </div>
+            </div>
+          {{ end }}  
+        </div>
+    </div>
+</div>

--- a/layouts/shortcourses/single.html
+++ b/layouts/shortcourses/single.html
@@ -1,0 +1,79 @@
+{{ partial "header.html" . }}
+{{ partial "navbar.html" . }}
+<div class="pub" itemscope>
+
+  {{ partial "header_image.html" . }}
+
+  <div class="article-container">
+
+    <div class="pub-title">
+      <h1 itemprop="name">{{ .Title }}</h1>
+    </div>
+    
+    <div class="row">
+      <div class="col-sm-1"></div>
+      <div class="col-sm-11">
+        <div class="row">
+          <div class="col-xs-12 col-sm-4 pub-row-heading">{{ i18n "institution" }}</div>
+          <div class="col-xs-12 col-sm-8">
+            {{ with .Params.institution_url }}<a href="{{ . }}" target="_blank" rel="noopener">{{ end }}
+            {{ .Params.institution | markdownify }}
+            {{ if .Params.institution_url }}</a>{{ end }}
+          </div>
+        </div>
+      </div>
+      <div class="col-sm-1"></div>
+    </div>
+    <div class="visible-xs space-below"></div>
+    
+    <div class="row">
+      <div class="col-sm-1"></div>
+      <div class="col-sm-11">
+        <div class="row">
+          <div class="col-xs-12 col-sm-4 pub-row-heading">{{ i18n "type_course" }}</div>
+          <div class="col-xs-12 col-sm-8">
+            {{ .Params.type_course | markdownify }}
+          </div>
+        </div>
+      </div>
+      <div class="col-sm-1"></div>
+    </div>
+    <div class="visible-xs space-below"></div>
+    
+    <div class="row">
+      <div class="col-sm-1"></div>
+      <div class="col-sm-11">
+        <div class="row">
+          <div class="col-xs-12 col-sm-4 pub-row-heading">{{ i18n "date" }}</div>
+          <div class="col-xs-12 col-sm-8">
+              {{ $date := .Params.time_start | default .Date }}
+              {{ (time $date).Format $.Site.Params.shortcourses.date_format }}
+          </div>
+        </div>
+      </div>
+      <div class="col-sm-1"></div>
+    </div>
+    <div class="visible-xs space-below"></div>
+    
+    <div class="row">
+      <div class="col-sm-1"></div>
+      <div class="col-sm-11">
+        <div class="row">
+          <div class="col-xs-12 col-sm-4 pub-row-heading">{{ i18n "commitment" }}</div>
+          <div class="col-xs-12 col-sm-8">
+              {{ .Params.commitment | markdownify }}
+          </div>
+        </div>
+      </div>
+      <div class="col-sm-1"></div>
+    </div>
+    <div class="visible-xs space-below"></div>
+    
+    <div class="space-below"></div>
+    
+    <div class="article-style">
+      {{ .Content }}
+</div>
+
+{{ partial "footer_container.html" . }}
+{{ partial "footer.html" . }}


### PR DESCRIPTION
### Purpose
Add Experience Section. `Fixes #538`

This is a correction to my first commit: `Pull #546`

### Screenshots

![print1](https://user-images.githubusercontent.com/29265753/42982466-6aed8dc2-8baf-11e8-8452-1cd5d0193e39.jpg)

![print2](https://user-images.githubusercontent.com/29265753/42982471-6e13020c-8baf-11e8-9af4-6d1344603e82.jpg)

### Documentation

I've added the files using the name "shortcourses". I've also changed the config.toml file to include the date format for the courses (under param.shortcourses). Also, I've included the specific translations to the language files, and some CSS options for the shortcourses widget.