### PR TITLE
Allow User to Select which Projects to be Displayed on Home Page

### DIFF
--- a/exampleSite/content/home/projects.md
+++ b/exampleSite/content/home/projects.md
@@ -20,6 +20,12 @@ folder = "project"
 # Legend: 0 = list, 1 = cards.
 view = 1
 
+# Exclude projects that are not selected?
+selected_only = false
+
+# Number of projects to list
+# count = 0
+
 # Filter toolbar.
 
 # Default filter index (e.g. 0 corresponds to the first `[[filter]]` instance below).

--- a/exampleSite/content/project/_index.md
+++ b/exampleSite/content/project/_index.md
@@ -1,0 +1,36 @@
++++
+title = "Projects"
+date = 2017-01-01T00:00:00
+math = false
+highlight = false
+
+# Customize how projects are listed.
+# Legend: 0 = list, 1 = cards.
+list_format = 1
+
+# Optional featured image (relative to `static/img/` folder).
+[header]
+image = ""
+caption = ""
+
+# Filter toolbar.
+
+# Default filter index (e.g. 0 corresponds to the first `[[filter]]` instance below).
+filter_default = 0
+
+# Add or remove as many filters (`[[filter]]` instances) as you like.
+# To show all items, set `tag` to "*".
+# To filter by a specific tag, set `tag` to an existing tag name.
+# To remove toolbar, delete/comment all instances of `[[filter]]` below.
+[[filter]]
+  name = "All"
+  tag = "*"
+
+[[filter]]
+  name = "Deep Learning"
+  tag = "Deep Learning"
+
+[[filter]]
+  name = "Other"
+  tag = "Demo"
++++

--- a/exampleSite/content/project/external-project/index.md
+++ b/exampleSite/content/project/external-project/index.md
@@ -15,6 +15,9 @@ tags = ["Demo"]
 # Optional external URL for project (replaces project detail page).
 external_link = "http://example.org"
 
+# Is this a selected project? (true/false)
+selected = true
+
 # Featured image
 # To use, add an image named `featured.jpg/png` to your project's folder. 
 [image]

--- a/exampleSite/content/project/internal-project/index.md
+++ b/exampleSite/content/project/internal-project/index.md
@@ -15,6 +15,9 @@ tags = ["Deep Learning"]
 # Optional external URL for project (replaces project detail page).
 external_link = ""
 
+# Is this a selected project? (true/false)
+selected = true
+
 # Featured image
 # To use, add an image named `featured.jpg/png` to your project's folder. 
 [image]

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -83,6 +83,11 @@
 - id: filter_all
   translation: Alle
 
+# Projects widget
+
+- id: more_projects
+  translation: Weitere Projekte
+
 # Project details
 
 - id: open_project_site

--- a/i18n/el.yaml
+++ b/i18n/el.yaml
@@ -118,6 +118,11 @@
 - id: filter_all
   translation: Όλα
 
+# Project widget
+
+- id: more_projects
+  translation: Περισσότερες Ερευνητικά προγράμματα
+
 # Project details
 
 - id: open_project_site

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -132,6 +132,11 @@
 - id: filter_all
   translation: All
 
+# Projects widget
+
+- id: more_projects
+  translation: More Projects
+
 # Project details
 
 - id: open_project_site

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -121,6 +121,11 @@
 - id: filter_all
   translation: Todo
 
+# Projects widget
+
+- id: more_projects
+  translation: Más Proyectos
+
 # Project details
 
 - id: open_project_site

--- a/i18n/eu.yaml
+++ b/i18n/eu.yaml
@@ -83,6 +83,11 @@
 - id: filter_all
   translation: Denak
 
+# Projects widget
+
+- id: more_projects
+  translation: Proiektu gehiago
+
 # Project details
 
 - id: open_project_site

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -121,6 +121,11 @@
 - id: filter_all
   translation: Tout
 
+# Projects widget
+
+- id: more_projects
+  translation: Plus de projets
+
 # Project details
 
 - id: open_project_site

--- a/i18n/id.yaml
+++ b/i18n/id.yaml
@@ -118,6 +118,11 @@
 - id: filter_all
   translation: Semua
 
+# Projects widget
+
+- id: more_projects
+  translation: Proyek lainnya
+
 # Project details
 
 - id: open_project_site

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -121,6 +121,11 @@
 - id: filter_all
   translation: Tutto
 
+# Projects widget
+
+- id: more_projects
+  translation: Altre Progetti
+
 # Project details
 
 - id: open_project_site

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -83,6 +83,11 @@
 - id: filter_all
   translation: 전부
 
+# Projects widget
+
+- id: more_projects
+  translation: 프로젝트 더 보기
+
 # Project details
 
 - id: open_project_site

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -83,6 +83,11 @@
 - id: filter_all
   translation: Alles
 
+# Projects widget
+
+- id: more_projects
+  translation: Meer Projecten
+
 # Project details
 
 - id: open_project_site

--- a/i18n/pl.yaml
+++ b/i18n/pl.yaml
@@ -97,6 +97,11 @@
 - id: filter_all
   translation: Wszystko
 
+# Projects widget
+
+- id: more_projects
+  translation: Więcej projektów
+
 # Project details
 
 - id: open_project_site

--- a/i18n/pt.yaml
+++ b/i18n/pt.yaml
@@ -83,6 +83,11 @@
 - id: filter_all
   translation: Todos
 
+# Projects widget
+
+- id: more_projects
+  translation: Mais Projetos
+
 # Project details
 
 - id: open_project_site

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -83,6 +83,11 @@
 - id: filter_all
   translation: Все
 
+# Projects widget
+
+- id: more_projects
+  translation: Больше проектов
+
 # Project details
 
 - id: open_project_site

--- a/i18n/tr.yaml
+++ b/i18n/tr.yaml
@@ -83,6 +83,11 @@
 - id: filter_all
   translation: Hepsi
 
+# Projects widget
+
+- id: more_projects
+  translation: Daha fazla projeler
+
 # Project details
 
 - id: open_project_site

--- a/i18n/vi.yaml
+++ b/i18n/vi.yaml
@@ -118,6 +118,11 @@
 - id: filter_all
   translation: Tất Cả
 
+# Projects widget
+
+- id: more_projects
+  translation: Dự Án Khác
+
 # Project details
 
 - id: open_project_site

--- a/i18n/zh.yaml
+++ b/i18n/zh.yaml
@@ -132,6 +132,11 @@
 - id: filter_all
   translation: 全部
 
+# Projects widget
+
+- id: more_projects
+  translation: 更多项目
+
 # Project details
 
 - id: open_project_site

--- a/layouts/partials/widgets/projects.html
+++ b/layouts/partials/widgets/projects.html
@@ -1,11 +1,29 @@
 {{ $ := .root }}
 {{ $page := .page }}
+{{ $.Scratch.Set "projects" (where $.Site.RegularPages "Type" ($page.Params.folder | default "project")) }}
+{{ $projects_len := len ($.Scratch.Get "projects") }}
+{{ if $page.Params.selected_only }}
+  {{ $.Scratch.Set "projects" (where ($.Scratch.Get "projects") ".Params.selected" true) }}
+{{ end }}
+{{ if $page.Params.count }}
+  {{ $.Scratch.Set "projects" (first $page.Params.count ($.Scratch.Get "projects")) }}
+{{ end }}
+{{ $projects := $.Scratch.Get "projects" }}
+
 
 <!-- Projects widget -->
 <div class="row">
   <div class="col-12 col-lg-4 section-heading">
     <h1>{{ with $page.Title }}{{ . | markdownify }}{{ end }}</h1>
     {{ with $page.Params.subtitle }}<p>{{ . | markdownify }}</p>{{ end }}
+    {{ if or $page.Params.selected_only (and $page.Params.count (gt $projects_len $page.Params.count)) }}
+    <p class="view-all">
+      <a href="{{ ($.Site.GetPage "section" ($page.Params.folder | default "project")).Permalink }}">
+        {{ i18n "more_projects" | markdownify }}
+        <i class="fa fa-angle-double-right"></i>
+      </a>
+    </p>
+    {{ end }}
   </div>
   <div class="col-12 col-lg-8">
     {{ with $page.Content }}<p>{{ . | markdownify }}</p>{{ end }}
@@ -48,7 +66,7 @@
     {{ if eq $page.Params.view 0 }}
 
     <div class="row isotope projects-container js-layout-row">
-        {{ range where $.Site.RegularPages "Type" ($page.Params.folder | default "project") }}
+        {{ range $projects }}
         <div class="col-lg-12 project-item isotope-item {{ delimit (apply .Params.tags "urlize" ".") " " }}" itemscope itemtype="http://schema.org/CreativeWork">
           <i class="far fa-copy pub-icon" aria-hidden="true"></i>
 
@@ -70,7 +88,7 @@
 
     <div class="row isotope projects-container js-layout-masonry">
 
-      {{ range $project := where $.Site.RegularPages "Type" ($page.Params.folder | default "project") }}
+      {{ range $project := $projects }}
         {{ $.Scratch.Set "project_url" $project.RelPermalink }}
         {{ $.Scratch.Set "target" "" }}
         {{ if $project.Params.external_link }}

--- a/layouts/section/project.html
+++ b/layouts/section/project.html
@@ -1,0 +1,109 @@
+{{ if .Params.widgets }}
+
+{{ partial "widget_page.html" . }}
+
+{{ else }}
+
+{{ partial "header.html" . }}
+{{ partial "navbar.html" . }}
+
+{{ partial "page_header.html" . }}
+
+<div class="universal-wrapper">
+  {{ with .Content }}
+  <div class="article-style" itemprop="articleBody">{{ . }}</div>
+  {{ end }}
+
+  {{ $paginator := .Paginate .Data.Pages }}
+  {{ if eq .Params.list_format 1 }}
+    <section id="projects">
+    {{ $page := . }}
+    {{ if $page.Params.filter }}
+
+    {{ $filter_default := default (int $page.Params.filter_default) 0 }}
+
+    {{/* Parse default filter tag from front matter in the form of either tag name or CSS class name. */}}
+    {{ $default_filter_tag_raw := (index $page.Params.filter ($filter_default)).tag }}
+    {{ $default_filter_tag := printf ".%s" (urlize $default_filter_tag_raw) }}
+    {{ if or (eq (substr $default_filter_tag_raw 0 1) "*") (eq (substr $default_filter_tag_raw 0 1) ".") }}
+      {{ $default_filter_tag = $default_filter_tag_raw }}
+    {{ end }}
+
+    <span class="d-none default-project-filter">{{ $default_filter_tag }}</span>
+
+    {{/* Only show filter buttons if there are multiple filters. */}}
+    {{ if gt (len $page.Params.filter) 1 }}
+    <div class="project-toolbar">
+      <div class="project-filters">
+        <div class="btn-toolbar">
+          <div class="btn-group flex-wrap">
+            {{ range $idx, $item := $page.Params.filter }}
+            {{/* Parse filter tag from front matter in the form of either tag name or CSS class name. */}}
+            {{ if or (eq (substr .tag 0 1) "*") (eq (substr .tag 0 1) ".") }}
+                {{ $.Scratch.Set "tag" .tag }}
+              {{ else }}
+                {{ $.Scratch.Set "tag" (printf ".%s" (urlize .tag)) }}
+              {{ end }}
+              <a href="#" data-filter="{{ $.Scratch.Get "tag" }}" class="btn btn-primary btn-lg{{ if eq $idx $filter_default }} active{{ end }}">{{ .name }}</a>
+            {{ end }}
+          </div>
+        </div>
+      </div>
+    </div>
+    {{ end }}
+    {{ end }}
+    <div class="row isotope projects-container js-layout-masonry">
+
+    {{ range $project := $paginator.Pages }}
+      {{ $.Scratch.Set "project_url" $project.RelPermalink }}
+      {{ $.Scratch.Set "target" "" }}
+      {{ if $project.Params.external_link }}
+      {{   $.Scratch.Set "project_url" $project.Params.external_link }}
+      {{   $.Scratch.Set "target" "target=\"_blank\" rel=\"noopener\"" }}
+      {{ end }}
+      {{ $resource := ($project.Resources.ByType "image").GetMatch "*featured*" }}
+      {{ $anchor := $project.Params.image.focal_point | default "Smart" }}
+    <div class="col-12 col-md-6 col-lg-4 project-item isotope-item {{ delimit (apply .Params.tags "urlize" ".") " " }}">
+      <div class="card">
+        {{ with $resource }}
+        {{ $image := .Fill (printf "550x550 q90 %s" $anchor) }}
+        <a href="{{ $.Scratch.Get "project_url" }}" {{ $.Scratch.Get "target" | safeHTMLAttr }} class="card-image hover-overlay"
+           {{ $.Scratch.Get "target" | safeHTMLAttr }}>
+          <img src="{{ $image.RelPermalink }}" alt="" class="img-responsive">
+        </a>
+        {{ end }}
+        <div class="card-text">
+          <h4><a href="{{ $.Scratch.Get "project_url" }}" {{ $.Scratch.Get "target" | safeHTMLAttr }}>{{ .Title }}</a></h4>
+          <div class="card-desription">
+            {{ with $project.Params.summary }}<p>{{ . | markdownify }}</p>{{ end }}
+          </div>
+        </div>
+      </div>
+    </div>
+    {{ end }}
+
+    </div>
+    </section>
+  {{ else }}
+    {{ range $paginator.Pages }}
+    <div>
+      <h2><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
+      <div class="article-style">
+        {{ if .Params.summary }}
+        {{ .Params.summary | plainify | emojify }}
+        {{ else if .Params.abstract }}
+        {{ .Params.abstract | plainify | emojify | truncate 250 }}
+        {{ else if .Summary }}
+        {{ .Summary | plainify | emojify }}
+        {{ end }}
+      </div>
+    </div>
+    {{ end }}
+  {{ end }}
+
+  {{ partial "pagination" . }}
+</div>
+{{ partial "footer_container.html" . }}
+{{ partial "footer.html" . }}
+
+{{ end }}


### PR DESCRIPTION
### Purpose

It might be helpful to select which projects to be displayed on the home page.
For example, there might be ongoing project as well as outdated projects, and users might only want to display ongoing projects.

This PR

1. Allows users to set `selected = true` on each project, and specify `selected_only = true` on projects section to only show selected projects.
2. Allows users to set `count = 3` on projects section to only show a specific number of projects.
3. When total number of projects > `count` or `selected_only = true`, show a link to all projects.
4. Add a project page that shows all projects.

### Screenshots
#### Project Widget
![image 1](https://i.imgur.com/C3HJlWa.png)
#### Project Page
![Imgur](https://i.imgur.com/flgAc2i.png)