### PR TITLE
Adding fax to contact page

### DIFF
--- a/layouts/partials/widgets/contact.html
+++ b/layouts/partials/widgets/contact.html
@@ -49,6 +49,15 @@
       </li>
       {{ end }}
 
+      {{ with $.Site.Params.fax }}
+      <li>
+        <i class="fa-li fa fa-fax fa-2x" aria-hidden="true"></i>
+        <span id="person-fax" itemprop="fax">
+        {{- if $autolink }}<a href="fax:{{ . }}">{{ . }}</a>{{ else }}{{ . }}{{ end -}}
+        </span>
+      </li>
+      {{ end }}
+
       {{ with $.Site.Params.skype }}
       <li>
         <i class="fa-li fa fa-skype fa-2x" aria-hidden="true"></i>


### PR DESCRIPTION
### Purpose

Adding a "fax" option to the contact page, for the academics that still have fax numbers.

### Screenshots

![screen shot 2018-07-30 at 14 01 54](https://user-images.githubusercontent.com/106480/43376974-2ced3d4c-9401-11e8-9c0c-cb83f1ed4ba1.png)
