### PR TITLE
Allow a summary to be specified for widget pages

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -12,14 +12,12 @@
   {{ $scr := .Scratch }}
   {{/* Generate page description. */}}
   {{ $scr.Set "description" .Site.Params.role }}
-  {{ if .IsPage }}
-    {{ if .Params.abstract }}
-      {{ $scr.Set "description" .Params.abstract }}
-    {{ else if .Params.summary }}
-      {{ $scr.Set "description" .Params.summary }}
-    {{ else }}
-      {{ $scr.Set "description" .Summary }}
-    {{ end }}
+  {{ if .Params.abstract }}
+    {{ $scr.Set "description" .Params.abstract }}
+  {{ else if .Params.summary }}
+    {{ $scr.Set "description" .Params.summary }}
+  {{ else if .IsPage }}
+    {{ $scr.Set "description" .Summary }}
   {{ end }}
   <meta name="description" content="{{ $scr.Get "description" }}">
 


### PR DESCRIPTION
### Purpose

Previously only pages used the abstract parameter to populate the description tag. It was not possible to set the description tag on widget sites.
This change fixes that.