### PR TITLE
(local) Social icons for project

### DIFF
--- a/archetypes/project.md
+++ b/archetypes/project.md
@@ -22,6 +22,14 @@ math = false
 # Does the project detail page use source code highlighting?
 highlight = true
 
+# Social/Academic Networking about the Project
+# Same as config.toml: Uncomment and copy/paste as many as needed
+#[[social]]
+#  icon = "github"
+#  icon_pack = "fa"
+#  link = "//github.com/gcushen"
+
+
 # Featured image
 # Place your image in the `static/img/` folder and reference its filename below, e.g. `image = "example.jpg"`.
 [header]

--- a/layouts/partials/css/academic.css
+++ b/layouts/partials/css/academic.css
@@ -856,6 +856,29 @@ article .article-metadata {
   z-index: 3;
 }
 
+.article-project ul.network-icon {
+  display: inline-flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: center;
+  list-style: none;
+  padding: 0;
+  margin-top: 30px;
+}
+
+.article-project .network-icon li {
+  margin-right: 10px;
+}
+
+.article-project .network-icon li:last-of-type {
+  margin-right: 0;
+}
+
+.article-project .network-icon li:hover {
+  transform: scale(1.2)
+}
+
+
 /*************************************************
  *  Card component
  **************************************************/

--- a/layouts/project/single.html
+++ b/layouts/project/single.html
@@ -13,6 +13,16 @@
       <span class="pull-right">
         {{ partial "share.html" . }}
       </span>
+      <ul class="network-icon" aria-hidden="true">
+	{{ range $.Params.social }}
+	{{ $pack := or .icon_pack "fa" }}
+	<li>
+          <a itemprop="sameAs" href="{{ .link | safeURL }}" target="_blank" rel="noopener">
+            <i class="{{ $pack }} {{ $pack }}-{{ .icon }} big-icon"></i>
+          </a>
+	</li>
+	{{ end }}
+      </ul>
     </div>
 
     {{ with .Params.external_link }}


### PR DESCRIPTION
### Purpose

`Fixes #326`
Add (local) social buttons for project, such as a github/gitlab link / youtube /....  

### Screenshots

![screenshot from 2018-08-01 15-52-17](https://user-images.githubusercontent.com/5602767/43525822-1a8bc4f4-95a3-11e8-8fc8-e2b3be465f4e.png)


### Documentation

- copy/paste the social <ul>...</ul> used for the profile
- copy the css and adapt it (#profile -> .article-project)
- Modify the archetypes file for project