### PR TITLE
[project] Option to have external_url set but still use its permalink

### DIFF
--- a/archetypes/project.md
+++ b/archetypes/project.md
@@ -13,8 +13,11 @@ summary = ""
 # Optional image to display on homepage.
 image_preview = ""
 
-# Optional external URL for project (replaces project detail page).
+# Optional external URL for project:
+#   replaces project detail page if keep_permalink==false
+#   display a link to the project website otherwise 
 external_link = ""
+keep_permalink = false
 
 # Does the project detail page use math formatting?
 math = false

--- a/layouts/partials/widgets/projects.html
+++ b/layouts/partials/widgets/projects.html
@@ -64,7 +64,7 @@
       {{ range $project := where $.Site.RegularPages "Type" ($page.Params.folder | default "project") }}
       {{ $.Scratch.Set "project_url" $project.Permalink }}
       {{ $.Scratch.Set "target" "" }}
-      {{ if $project.Params.external_link }}
+      {{ if and (not ($project.Params.keep_permalink)) ($project.Params.external_link) }}
       {{   $.Scratch.Set "project_url" $project.Params.external_link }}
       {{   $.Scratch.Set "target" "target=\"_blank\"" }}
       {{ end }}


### PR DESCRIPTION
### Purpose

Currently, for a project, if `external_link` is filled then the "local" project page is not accessible from the homepage. On the other hand, on the local project page (accessible through direct url), the design propose a button to the "project webpage" (`external_link`), and sometimes we like to have a summary of the project on our webpage and an exterior link to the project webpage.

This commit propose an option `keep_permalink` so that if yes, the local link will always be used. If`keep_permalink` is not defined then the default behavior is used, so this commit should not impact others instance of the theme.

### Documentation

New option for project : `keep_permalink` to use both `external_link` option and the local page of the project.