### PR TITLE
Load search.json  corresponding to lang

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -66,7 +66,7 @@
     {{ if ne .Site.Params.search.engine 0 }}
     {{/* Configure search engine. */}}
     <script>
-      const search_index_filename = {{ "/search.json" | relURL }};
+      const search_index_filename = {{ "/search.json" | relLangURL }};
       const i18n = {
         'placeholder': {{ i18n "search_placeholder" }},
         'no_results': {{ i18n "search_no_results" }}


### PR DESCRIPTION
Hello,
As reported in https://github.com/gcushen/hugo-academic/issues/635#issuecomment-416052745

We do not load the right search.json, this PR fix this by using `relLangURL` instead of `relURL`

Regards,

