### PR TITLE
Allow for custom publication status

### DIFF
--- a/archetypes/publication.md
+++ b/archetypes/publication.md
@@ -57,6 +57,10 @@ url_source = ""
 #   Uncomment line below to enable. For multiple links, use the form `[{...}, {...}, {...}]`.
 # url_custom = [{name = "Custom Link", url = "http://example.org"}]
 
+# Custom status (optional).
+#   Uncomment line below to enable. Replaces date with content of your choice.
+# custom_status = "In Press"
+
 # Does this page contain LaTeX math? (true/false)
 math = false
 

--- a/exampleSite/content/publication/clothing-search.md
+++ b/exampleSite/content/publication/clothing-search.md
@@ -57,6 +57,10 @@ url_source = "#"
 #   Uncomment line below to enable. For multiple links, use the form `[{...}, {...}, {...}]`.
 url_custom = [{name = "Custom Link", url = "http://example.org"}]
 
+# Custom status (optional).
+#   Uncomment line below to enable. Replaces date with content of your choice.
+# custom_status = "In Press"
+
 # Does this page contain LaTeX math? (true/false)
 math = true
 

--- a/exampleSite/content/publication/person-re-identification.md
+++ b/exampleSite/content/publication/person-re-identification.md
@@ -57,6 +57,10 @@ url_source = ""
 #   Uncomment line below to enable. For multiple links, use the form `[{...}, {...}, {...}]`.
 # url_custom = [{name = "Custom Link", url = "http://example.org"}]
 
+# Custom status (optional).
+#   Uncomment line below to enable. Replaces date with content of your choice.
+# custom_status = "In Press"
+
 # Does this page contain LaTeX math? (true/false)
 math = true
 

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -113,6 +113,9 @@
 - id: location
   translation: Location
 
+- id: status
+  translation: Status
+
 # Filtering
 
 - id: filter_by_type

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -113,6 +113,9 @@
 - id: location
   translation: Localización
 
+- id: status
+  translation: Estado
+
 # Filtering
 
 - id: filter_by_type

--- a/layouts/partials/publication_li_apa.html
+++ b/layouts/partials/publication_li_apa.html
@@ -5,7 +5,11 @@
       {{- delimit . ", " | markdownify -}}
     {{- end -}}
   </span>
-  ({{- .Date.Format "2006" -}}).
+  {{ if .Params.custom_status }}
+    ({{ .Params.custom_status | markdownify }}).
+  {{ else }}
+    ({{- .Date.Format "2006" -}}).
+  {{ end}}
   <a href="{{ .Permalink }}" itemprop="name">{{ .Title }}</a>.
   {{ if .Params.publication_short }}
     {{- .Params.publication_short | markdownify -}}.

--- a/layouts/partials/publication_li_detailed.html
+++ b/layouts/partials/publication_li_detailed.html
@@ -42,7 +42,11 @@
     {{ else if .Params.publication }}
     {{ .Params.publication | markdownify }},
     {{ end }}
-    {{ .Date.Format "2006" }}
+    {{ if .Params.custom_status }}
+      {{.Params.custom_status | markdownify}}.
+    {{ else }}
+      {{- .Date.Format "2006" -}}.
+    {{ end}}
   </div>
 
   <div class="pub-links">

--- a/layouts/partials/publication_li_mla.html
+++ b/layouts/partials/publication_li_mla.html
@@ -11,6 +11,10 @@
   {{ else if .Params.publication }}
     {{- .Params.publication | markdownify -}},
   {{ end }}
-  {{- .Date.Format "2006" -}}.
+  {{ if .Params.custom_status }}
+    {{.Params.custom_status | markdownify}}.
+  {{ else }}
+    {{- .Date.Format "2006" -}}.
+  {{ end}}
   <p>{{ partial "publication_links" (dict "content" . "is_list" 1) }}</p>
 </div>

--- a/layouts/partials/publication_li_simple.html
+++ b/layouts/partials/publication_li_simple.html
@@ -1,6 +1,9 @@
 <div class="pub-list-item" style="margin-bottom: 1rem" itemscope itemtype="http://schema.org/CreativeWork">
   <i class="far fa-file-alt pub-icon" aria-hidden="true"></i>
   <a href="{{ .Permalink }}" itemprop="name">{{ .Title }}</a>
+  {{ if .Params.custom_status }}
+    [{{ .Params.custom_status | markdownify }}].
+  {{ end}}
   <div itemprop="author">
     {{ with .Params.authors }}
       {{- delimit . ", " | markdownify -}}

--- a/layouts/publication/single.html
+++ b/layouts/publication/single.html
@@ -58,19 +58,35 @@
     <div class="visible-xs space-below"></div>
     {{ end }}
 
-    <div class="row">
-      <div class="col-sm-1"></div>
-      <div class="col-sm-10">
-        <div class="row">
-          <div class="col-xs-12 col-sm-3 pub-row-heading">{{ i18n "date" }}</div>
-          <div class="col-xs-12 col-sm-9" itemprop="datePublished">
-            {{ .Date.Format ($.Site.Params.publications.date_format | default "January, 2006") }}
+    {{ if .Params.custom_status }}
+      <div class="row">
+        <div class="col-sm-1"></div>
+        <div class="col-sm-10">
+          <div class="row">
+            <div class="col-xs-12 col-sm-3 pub-row-heading">{{ i18n "status" }}</div>
+            <div class="col-xs-12 col-sm-9" itemprop="datePublished">
+              {{.Params.custom_status | markdownify}}.
+            </div>
           </div>
         </div>
+        <div class="col-sm-1"></div>
       </div>
-      <div class="col-sm-1"></div>
-    </div>
-    <div class="visible-xs space-below"></div>
+      <div class="visible-xs space-below"></div>
+    {{ else }}
+      <div class="row">
+        <div class="col-sm-1"></div>
+        <div class="col-sm-10">
+          <div class="row">
+            <div class="col-xs-12 col-sm-3 pub-row-heading">{{ i18n "date" }}</div>
+            <div class="col-xs-12 col-sm-9" itemprop="datePublished">
+              {{ .Date.Format ($.Site.Params.publications.date_format | default "January, 2006") }}
+            </div>
+          </div>
+        </div>
+        <div class="col-sm-1"></div>
+      </div>
+      <div class="visible-xs space-below"></div>
+    {{ end}}
 
     <div class="row" style="padding-top: 10px">
       <div class="col-sm-1"></div>

--- a/layouts/publication/single.html
+++ b/layouts/publication/single.html
@@ -65,7 +65,7 @@
           <div class="row">
             <div class="col-xs-12 col-sm-3 pub-row-heading">{{ i18n "status" }}</div>
             <div class="col-xs-12 col-sm-9" itemprop="datePublished">
-              {{.Params.custom_status | markdownify}}.
+              {{.Params.custom_status | markdownify}}
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Purpose

Sometimes one would like to add a publication that is not yet accepted or is otherwise in preparation. Currently, the date still appears for these. This PR allows the user to add a custom status to appear instead of the date. The date field remains useful for sorting the entries (e.g. if the "in progress" publications have a date set to today's date, they will appear at the top of the list as per issue #388).

### Screenshots

_Please ignore the custom logos and custom details from #596_

`custom_status = "Under Review: TAAC-D-18-00175"`

#### Publications list (Simple)

No date here, so added the status to the end of the title.

![image](https://user-images.githubusercontent.com/870746/44958628-06b88300-aeb1-11e8-87e4-fb2de56a28d3.png)

#### Publications list (Detailed)

![image](https://user-images.githubusercontent.com/870746/44958644-23ed5180-aeb1-11e8-9c40-4ad2b45c9e42.png)

#### Publications list (APA)

![image](https://user-images.githubusercontent.com/870746/44958670-5dbe5800-aeb1-11e8-9dd7-4cc8f74440a8.png)

#### Publications list (MLA)

![image](https://user-images.githubusercontent.com/870746/44958678-79296300-aeb1-11e8-9302-05925a159914.png)

#### Publication details

![image](https://user-images.githubusercontent.com/870746/44958680-96f6c800-aeb1-11e8-9a0f-a6318a149d71.png)

_Note for the above, I will push a commit to remove the extra period._

### Documentation

I have added the option to the archetype and the example site publications.
