### PR TITLE
Allow description meta tag to be specified separately from the role.

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -60,6 +60,9 @@ enableGitInfo = false
   name = "Lena Smith"
   role = "Professor of Artificial Intelligence"
 
+  # Description meta tag for search engines. If undefined, role is used in place.
+  meta_description = "Professor of Artificial Intelligence at Stanford University."
+
   # Organizations/Affiliations.
   #   Separate multiple entries with a comma, using the form: `[ {name="Org1", url=""}, {name="Org2", url=""} ]`.
   organizations = [ { name = "Stanford University", url = "" } ]

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -48,20 +48,11 @@ enableGitInfo = false
   smartypants = true  # `false` disables all smart punctuation substitutions (e.g. smart quotes, dashes, fractions).
 
 [params]
-  # Color theme.
-  #   Choose from `default`, `ocean`, `forest`, `coffee`, `dark`, or `1950s`.
-  color_theme = "default"
-
-  # Font style.
-  #   Choose from `default`, `classic`, or `playfair`.
-  font = "default"
+  # AUTHOR SETUP
 
   # Your details.
   name = "Lena Smith"
   role = "Professor of Artificial Intelligence"
-
-  # Description meta tag for search engines. If undefined, role is used in place.
-  meta_description = "Professor of Artificial Intelligence at Stanford University."
 
   # Organizations/Affiliations.
   #   Separate multiple entries with a comma, using the form: `[ {name="Org1", url=""}, {name="Org2", url=""} ]`.
@@ -69,24 +60,19 @@ enableGitInfo = false
 
   gravatar = false  # Get your avatar from Gravatar.com? (true/false)
   avatar = "portrait.jpg"  # Specify an avatar image (in `static/img/` folder) or delete value to disable avatar.
+  
+  # Details for the Contact Widget
   email = "test@example.org"
   address = "Building 1 Room 1, Stanford University, California, 90210, USA"
   office_hours = "Monday 10:00 to 13:00 or email for appointment"
   phone = "888 888 88 88"
-  twitter = ""
   skype = "echo123"
   telegram = ""
-
-  # Enable Keybase in Contact widget by entering your keybase.io username.
-  keybase = ""
+  keybase = ""  # Your keybase.io username.
 
   # Discussion link (e.g. link to a forum, mailing list, or chat).
   #   Uncomment line below to use.
   #   discussion = { name = "Discuss", url = "https://discourse.gohugo.io" }
-
-  # Diplay a logo in navigation bar rather than title (optional).
-  #   To enable, place an image in `static/img/` and reference its filename below. To disable, set the value to "".
-  logo = ""
 
   # Enable/disable map in Contact widget.
   # To show your address on a map in the contact widget, you need to enter your latitude, longitude and choose
@@ -108,6 +94,29 @@ enableGitInfo = false
   latitude = "37.4275"
   longitude = "-122.1697"
   zoom = 15
+
+  # SITE SETUP
+
+  # Color theme.
+  #   Choose from `default`, `ocean`, `forest`, `coffee`, `dark`, or `1950s`.
+  color_theme = "default"
+
+  # Font style.
+  #   Choose from `default`, `classic`, or `playfair`.
+  font = "default"
+
+  # Description for social sharing and search engines. If undefined, author role is used in place.
+  description = ""
+  
+  # Default image for social sharing and search engines. Place image in `static/img/` folder and specify image name here.
+  sharing_image = ""
+
+  # Twitter username (without @). Used when a vistor shares your site on Twitter.
+  twitter = ""
+
+  # Diplay a logo in navigation bar rather than title (optional).
+  #   To enable, place an image in `static/img/` and reference its filename below. To disable, set the value to "".
+  logo = ""
 
   # Date and time format (refer to https://sourcethemes.com/academic/docs/customization/#date-format )
   #   Examples: "Mon, Jan 2, 2006" or "2006-01-02"

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -11,7 +11,11 @@
 
   {{ $scr := .Scratch }}
   {{/* Generate page description. */}}
-  {{ $scr.Set "description" .Site.Params.role }}
+  {{ if .Site.Params.meta_description }}
+    {{$scr.Set "description" .Site.Params.meta_description }}
+  {{ else }}
+    {{$scr.Set "description" .Site.Params.role }}
+  {{ end }}
   {{ if .Params.abstract }}
     {{ $scr.Set "description" .Params.abstract }}
   {{ else if .Params.summary }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -11,19 +11,19 @@
 
   {{ $scr := .Scratch }}
   {{/* Generate page description. */}}
-  {{ if .Site.Params.meta_description }}
-    {{$scr.Set "description" .Site.Params.meta_description }}
-  {{ else }}
-    {{$scr.Set "description" .Site.Params.role }}
-  {{ end }}
-  {{ if .Params.abstract }}
-    {{ $scr.Set "description" .Params.abstract }}
-  {{ else if .Params.summary }}
-    {{ $scr.Set "description" .Params.summary }}
+  {{ $desc := "" }}
+  {{ if .Params.summary }}
+    {{ $desc = .Params.summary }}
+  {{ else if .Params.abstract }}
+    {{ $desc = .Params.abstract }}
   {{ else if .IsPage }}
-    {{ $scr.Set "description" .Summary }}
+    {{ $desc = .Summary }}
+  {{ else if .Site.Params.description }}
+    {{ $desc = .Site.Params.description }}
+  {{ else }}
+    {{ $desc = .Site.Params.role }}
   {{ end }}
-  <meta name="description" content="{{ $scr.Get "description" }}">
+  <meta name="description" content="{{ $desc }}">
 
   {{ range .Translations }}
   <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}">
@@ -129,8 +129,16 @@
   <meta property="og:site_name" content="{{ .Site.Title }}">
   <meta property="og:url" content="{{ .Permalink }}">
   <meta property="og:title" content="{{ if not .IsHome }}{{ .Title }} | {{ end }}{{ .Site.Title }}">
-  <meta property="og:description" content="{{ $scr.Get "description" }}">
-  {{- with .Params.header.image }}<meta property="og:image" content="{{ printf "img/%s" . | absURL }}">{{end}}
+  <meta property="og:description" content="{{ $desc }}">
+  {{ $og_image := "" }}
+  {{ if .Params.header.image }}
+    {{ $og_image = .Params.header.image }}
+  {{ else if .Site.Params.sharing_image }}
+    {{ $og_image = .Site.Params.sharing_image }}
+  {{ else }}
+    {{ $og_image = "icon-192.png" }}
+  {{ end }}
+  {{- with $og_image }}<meta property="og:image" content="{{ printf "img/%s" . | absURL }}">{{end}}
   <meta property="og:locale" content="{{ .Site.LanguageCode | default "en-us" }}">
   {{ if .IsPage }}
   {{ if not .PublishDate.IsZero }}<meta property="article:published_time" content="{{ .PublishDate.Format "2006-01-02T15:04:05-07:00" | safeHTML }}">


### PR DESCRIPTION
If it is set, the 'meta_description' Param now used instead of 'role' to set the description meta tag.

### Purpose

Having just the role in the description meta tag does not make sense for optimizing search results. This approach provides the user the ability to easily set the tag in the config.toml file.

