### PR TITLE
Load MathJax config without eval()

### DIFF
--- a/assets/js/mathjax-config.js
+++ b/assets/js/mathjax-config.js
@@ -1,0 +1,6 @@
+window.MathJax = {
+  CommonHTML: { linebreaks: { automatic: true } },
+  tex2jax: { inlineMath: [ ['$', '$'], ['\\(','\\)'] ], displayMath: [ ['$$','$$'], ['\\[', '\\]'] ], processEscapes: false },
+  TeX: { noUndefined: { attributes: { mathcolor: 'red', mathbackground: '#FFEEEE', mathsize: '90%' } } },
+  messageStyle: 'none'
+};

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,14 +2,9 @@
 
     {{/* Config LaTeX math rendering. */}}
     {{ if or .Params.math .Site.Params.math }}
-    <script type="text/x-mathjax-config">
-      MathJax.Hub.Config({
-        CommonHTML: { linebreaks: { automatic: true } },
-        tex2jax: { inlineMath: [ ['$', '$'], ['\\(','\\)'] ], displayMath: [ ['$$','$$'], ['\\[', '\\]'] ], processEscapes: false },
-        TeX: { noUndefined: { attributes: { mathcolor: 'red', mathbackground: '#FFEEEE', mathsize: '90%' } } },
-        messageStyle: 'none'
-      });
-    </script>
+    {{ $js := resources.Get "js/mathjax-config.js" }}
+    {{ $secureJS := $js | resources.Fingerprint "sha512" }}
+    <script type="text/javascript" src="{{ $secureJS.Permalink }}" integrity="{{ $secureJS.Data.Integrity }}"></script>
     {{ end }}
 
     {{/* Attempt to load local vendor JS, otherwise load from CDN. */}}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,9 +2,9 @@
 
     {{/* Config LaTeX math rendering. */}}
     {{ if or .Params.math .Site.Params.math }}
-    {{ $js := resources.Get "js/mathjax-config.js" }}
-    {{ $secureJS := $js | resources.Fingerprint "sha512" }}
-    <script type="text/javascript" src="{{ $secureJS.Permalink }}" integrity="{{ $secureJS.Data.Integrity }}"></script>
+    {{ $mathjax_config := resources.Get "js/mathjax-config.js" }}
+    {{ $secureJS := $mathjax_config | resources.Fingerprint "sha512" }}
+    <script src="{{ $secureJS.Permalink }}" integrity="{{ $secureJS.Data.Integrity }}"></script>
     {{ end }}
 
     {{/* Attempt to load local vendor JS, otherwise load from CDN. */}}


### PR DESCRIPTION
This allows more strict content security policies. Also uses SRI.