### PR TITLE
Pages widget options: exclude past/future (for talk)

### DIFF
--- a/exampleSite/content/home/talks.md
+++ b/exampleSite/content/home/talks.md
@@ -28,6 +28,8 @@ subtitle = ""
     category = ""
     publication_type = ""
     exclude_featured = false
+    exclude_upcoming = false
+    exclude_past = false
   
 [design]
   # Toggle between the various page layout types.

--- a/exampleSite/content/home/talks.md
+++ b/exampleSite/content/home/talks.md
@@ -28,9 +28,9 @@ subtitle = ""
     category = ""
     publication_type = ""
     exclude_featured = false
-    exclude_upcoming = false
     exclude_past = false
-  
+    exclude_future = false
+    
 [design]
   # Toggle between the various page layout types.
   #   1 = List

--- a/layouts/partials/widgets/pages.html
+++ b/layouts/partials/widgets/pages.html
@@ -33,11 +33,11 @@
 {{ if $st.Params.content.filters.exclude_featured }}
   {{ $query = where $query "Params.featured" "!=" true }}
 {{ end }}
-{{ if $st.Params.content.filters.exclude_upcoming }}
-  {{ $query = where $query "Params.time_start" "<=" now }}
-{{ end }}
 {{ if $st.Params.content.filters.exclude_past }}
-  {{ $query = where $query "Params.time_start" ">=" now }}
+  {{ $query = where $query "Date" "<=" now }}
+{{ end }}
+{{ if $st.Params.content.filters.exclude_future }}
+  {{ $query = where $query "Date" ">" now }}
 {{ end }}
 
 {{/* Sort */}}

--- a/layouts/partials/widgets/pages.html
+++ b/layouts/partials/widgets/pages.html
@@ -33,6 +33,12 @@
 {{ if $st.Params.content.filters.exclude_featured }}
   {{ $query = where $query "Params.featured" "!=" true }}
 {{ end }}
+{{ if $st.Params.content.filters.exclude_upcoming }}
+  {{ $query = where $query "Params.time_start" "<=" now }}
+{{ end }}
+{{ if $st.Params.content.filters.exclude_past }}
+  {{ $query = where $query "Params.time_start" ">=" now }}
+{{ end }}
 
 {{/* Sort */}}
 {{ $sort_by := "" }}


### PR DESCRIPTION
### Purpose

Upgrade Talk widget by adding three options:
- `order`: ascending or descending order
- `exclude_past`: when true the widget will exclude the "past" talks. 
- `exclude_upcoming`: same but for upcoming talks

As we are dealing with static website, the dates of talks are compared to the `now` function and hence to the last building date.

As explained in `#721`, these options allow to re-use the talks widget: one for the past (descending order), one for the upcoming (ascending order), without having to move or change the talks/files.md. 

If a talk has been given, rebuilding the website will "move" it to the "past" talk without having to move a file and hence changing its URL.

### Screenshots

![screenshot](https://user-images.githubusercontent.com/5602767/47440395-5c712380-d7ae-11e8-8b70-2b3de4672fd7.png)

### Documentation

A priori, there is no break in previous implementation (if not set, options are set as default).
