### PR TITLE
Fixed catalan typo

### DIFF
--- a/i18n/ca.yaml
+++ b/i18n/ca.yaml
@@ -64,7 +64,7 @@
 # About widget
 
 - id: interests
-  translation: Interesos
+  translation: Interessos
 
 - id: education
   translation: Educació


### PR DESCRIPTION
### Purpose

Fixed catalan typo.

### Documentation

According to Catalan dictionary, plural has two `ss` , not one.

https://dlc.iec.cat/results.asp?txtEntrada=interessos&operEntrada=0
