### PR TITLE
feat: enable to choose twitter card type

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -113,6 +113,8 @@ enableGitInfo = false
 
   # Twitter username (without @). Used when a vistor shares your site on Twitter.
   twitter = ""
+  # Twitter card type. (refer to https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/abouts-cards )
+  twitter_card_type = ""
 
   # Diplay a logo in navigation bar rather than title (optional).
   #   To enable, place an image in `static/img/` and reference its filename below. To disable, set the value to "".

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -121,7 +121,7 @@
 
   <link rel="canonical" href="{{ .Permalink }}">
 
-  <meta property="twitter:card" content="summary_large_image">
+  <meta property="twitter:card" content="{{ .Site.Params.twitter_card_type | default "summary" }}">
   {{ with .Site.Params.twitter }}
   <meta property="twitter:site" content="@{{ . }}">
   <meta property="twitter:creator" content="@{{ . }}">


### PR DESCRIPTION
### Purpose
Enable to choose twitter card type by config.toml

If use summary_large_image(default now in this theme),
the image is enlarged, and the content of the icon is difficult to understand.

cf. https://github.com/gcushen/hugo-academic/pull/358

### Screenshots
before
<img width="1054" alt="2018-11-15 8 48 39" src="https://user-images.githubusercontent.com/10177370/48520906-be0c4580-e8b5-11e8-84b5-9763cbaf023d.png">

after
<img width="1069" alt="2018-11-15 8 50 49" src="https://user-images.githubusercontent.com/10177370/48520927-d3816f80-e8b5-11e8-9ee2-901b635154d1.png">

### Documentation
Sorry, I cloud not found any documentation.
Only found in bellow.
https://sourcethemes.com/academic/updates/v2.1.0/

