### PR TITLE
Fix Hero widget and Search for multilingual sites

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -55,7 +55,7 @@
     {{ if ne .Site.Params.search.engine 0 }}
     {{/* Configure search engine. */}}
     <script>
-      const search_index_filename = {{ "/index.json" | relURL }};
+      const search_index_filename = {{ "/index.json" | relLangURL }};
       const i18n = {
         'placeholder': {{ i18n "search_placeholder" }},
         'results': {{ i18n "search_results" }},

--- a/layouts/partials/widgets/hero.html
+++ b/layouts/partials/widgets/hero.html
@@ -5,7 +5,7 @@
 {{/* Compute image path outside of HTML style element due to Hugo limitation. */}}
 {{ $overlay_img := "" }}
 {{ if $header.overlay_img }}
-  {{ $overlay_img = (printf "img/%s" $header.overlay_img) }}
+  {{ $overlay_img = (printf "img/%s" $header.overlay_img) | relURL }}
 {{end}}
 
 <section id="{{ $page.File.TranslationBaseName }}" class="hero-overlay" style="


### PR DESCRIPTION
### Purpose

In multilingual sites, the hero widget and the search box are built with URLs without include the baseUrl and the language prefix. This pull request fixes the problem.

Enable the option "defaultContentLanguageInSubdir" and add a language in exampleSite/config.toml for reproduce the error.
