### PR TITLE
Modify featurette class column to have two skills per row in mobile

### DIFF
--- a/layouts/partials/widgets/featurette.html
+++ b/layouts/partials/widgets/featurette.html
@@ -21,7 +21,7 @@
   {{ if in (slice "fab" "fas" "far" "fal") $pack }}
     {{ $pack_prefix = "fa" }}
   {{ end }}
-  <div class="col-12 col-sm-4">
+  <div class="col-6 col-sm-4">
     {{ with .icon }}<div class="featurette-icon"><i class="{{ $pack }} {{ $pack_prefix }}-{{ . }}"></i></div>{{ end }}
     <h3>{{ .name | markdownify | emojify }}</h3>
     {{ with .description }}<p>{{ . | markdownify | emojify }}</p>{{ end }}


### PR DESCRIPTION
### Purpose
This little change allow to have two skills per row on mobile. It was only one per row and it took unnecessary width.

### Screenshots
**Before:**
<img width="401" alt="before" src="https://user-images.githubusercontent.com/9849996/49045231-9def5700-f1d0-11e8-83f0-5e5d5227198e.png">

**After the changes:**
<img width="400" alt="after" src="https://user-images.githubusercontent.com/9849996/49045244-aba4dc80-f1d0-11e8-94c9-62bd01c246db.png">

The layout remains unchanged on bigger screen.

