### PR TITLE
right align date in experience widget

### DIFF
--- a/layouts/partials/widgets/experience.html
+++ b/layouts/partials/widgets/experience.html
@@ -33,7 +33,7 @@
         <div class="card">
           <div class="card-body">
             <div class="float-right text-muted exp-meta">
-              <div>
+              <div class="text-right">
                 {{ (time .date_start).Format ($page.Params.date_format | default "January 2006") }} –
                 {{ if .date_end}}
                   {{ (time .date_end).Format ($page.Params.date_format | default "January 2006") }}


### PR DESCRIPTION
### Purpose

Dates in the experience widget don't currently right align if the location string is longer than the date string. This changes the widget so the dates are always right aligned.