### PR TITLE
add tags to page_metadata

### DIFF
--- a/layouts/partials/page_metadata.html
+++ b/layouts/partials/page_metadata.html
@@ -45,6 +45,20 @@
   <a href="{{ $.RelPermalink }}#disqus_thread"><!-- Count will be inserted here --></a>
   {{ end}}
 
+  <!-- copied from partials/tags.html -->
+  {{ if isset $.Params "tags" }}
+
+  <span class="middot-divider"></span>
+  {{ $tagsLen := len $.Params.tags }}
+  {{ if gt $tagsLen 0 }}
+  <!-- <div class="article-tags"> -->
+    {{ range $k, $v := $.Params.tags }}
+    <a class="badge badge-light" href="{{ ($.Site.GetPage (printf "tags/%s" .)).RelPermalink }}">{{ . }}</a>
+    {{ end }}
+  <!-- </div> -->
+  {{ end }}
+  {{ end }}
+
   {{ if $.Params.categories }}
   {{ $categoriesLen := len $.Params.categories }}
   {{ if gt $categoriesLen 0 }}


### PR DESCRIPTION
### Purpose

I wanted to add tags to display in the page_metadata.

### Screenshots

Now, we display tags alongside the other content in page_metadata

![image](https://user-images.githubusercontent.com/1750621/50578145-89236600-0e03-11e9-8159-f97fbe845f4f.png)


### Documentation

If this is an enhancement, add a link here to the corresponding pull request on https://github.com/sourcethemes/academic-www or describe the documentation changes necessary.
