### PR TITLE
[fix] css for alert shortcode

### DIFF
--- a/layouts/partials/css/academic.css
+++ b/layouts/partials/css/academic.css
@@ -1660,7 +1660,7 @@ table > tbody > tr:hover > th {
  *  Alerts
  **************************************************/
 
-div.alert p {
+div.alert > p {
   position: relative;
   display: block;
   font-size: 1rem;
@@ -1669,7 +1669,7 @@ div.alert p {
   margin-bottom: 0;
 }
 
-div.alert p:first-child::before {
+div.alert > p:first-child::before {
   position: absolute;
   top: -0.5rem;
   left: -2rem;
@@ -1682,7 +1682,7 @@ div.alert p:first-child::before {
   text-align: center;
 }
 
-div.alert-warning p:first-child::before {
+div.alert-warning > p:first-child::before {
   font-family: 'Font Awesome 5 Free';
   font-weight: 900;
   color: #ff3860;


### PR DESCRIPTION
### Purpose

Using `docs` layout, the `{{% alert %}}` shortcode associated css apply a rule for every `<p>` instead of, only, the first one and/or the direct child of `<div>`. This can lead to mistakes. 

### Screenshots

Using this code:
```
{{% alert note %}}
This is the first paragraph of `<div>`

- But then here another one!

    ```bash
    git
    ```
- Comes another one !
{{% /alert %}}
```
Before fix:
![hugo_before](https://user-images.githubusercontent.com/5602767/51041857-1a8c9800-15bb-11e9-89da-2aac6af0b1cd.png)

After fix:
![hugo_after](https://user-images.githubusercontent.com/5602767/51041861-1ceef200-15bb-11e9-9d46-ea69fbe6e3d9.png)


### The fix

It only consist in adding `>` in the css files to specify that rules only work for the direct childs `<p>` of `<div>`.
