### PR TITLE
Microdata fixes in publications

### DIFF
--- a/layouts/partials/page_links.html
+++ b/layouts/partials/page_links.html
@@ -19,7 +19,7 @@
   {{ $pdf = .RelPermalink }}
 {{ else }}
   {{ if $.Params.url_pdf }}
-    {{ $pdf = $.Params.url_pdf | relURL }}
+    {{ $pdf = $.Params.url_pdf | absURL }}
   {{ end }}
 {{ end }}
 {{ with $pdf }}
@@ -126,7 +126,7 @@
 </a>
 {{ end }}
 {{ with $.Params.doi }}
-<a class="btn btn-outline-primary my-1 mr-1{{ if $is_list }} btn-sm{{end}}" href="https://doi.org/{{ . }}" target="_blank" rel="noopener">
+<a class="btn btn-outline-primary my-1 mr-1{{ if $is_list }} btn-sm{{end}}" href="https://doi.org/{{ . }}" target="_blank" rel="noopener" itemprop="sameAs">
   DOI
 </a>
 {{ end }}

--- a/layouts/partials/publication_li_stream.html
+++ b/layouts/partials/publication_li_stream.html
@@ -14,17 +14,17 @@
       {{ $summary = .Summary }}
     {{ end }}
     {{ with $summary }}
-    <div class="article-style" itemprop="articleBody">
+    <div class="article-style">
       {{ . | truncate 135 }}
     </div>
     {{ end }}
 
     <div class="stream-meta article-metadata">
-      <div itemprop="author">
-        {{ with .Params.authors }}
-        {{- delimit . ", " | markdownify -}}
-        {{- end -}}
-      </div>
+      {{ with .Params.authors }}
+          <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">
+          {{- delimit . "</span></span>, <span itemprop=\"author\" itemscope itemtype=\"http://schema.org/Person\"><span itemprop=\"name\">" | markdownify -}}
+      </span></span>
+      {{ end -}}
     </div>
 
     <div class="btn-links">

--- a/layouts/partials/widgets/about.html
+++ b/layouts/partials/widgets/about.html
@@ -17,7 +17,7 @@
 {{ $avatar := ($person_page.Resources.ByType "image").GetMatch "*avatar*" }}
 
 <!-- About widget -->
-<div class="row" itemprop="author" itemscope itemtype="http://schema.org/Person" itemref="{{ if $.Site.Params.email }}person-email{{ end }}{{ if $.Site.Params.phone }} person-telephone{{ end }}{{ if $.Site.Params.address}} person-address{{ end }}">
+<div class="row" itemprop="author" itemscope itemtype="http://schema.org/Person">
   <div class="col-12 col-lg-4">
     <div id="profile">
 

--- a/layouts/publication/single.html
+++ b/layouts/publication/single.html
@@ -1,6 +1,6 @@
 {{ partial "header.html" . }}
 {{ partial "navbar.html" . }}
-<div class="pub" itemscope itemtype="http://schema.org/CreativeWork">
+<div class="pub" itemscope itemtype="http://schema.org/ScholarlyArticle">
 
   {{ partial "page_header.html" . }}
 
@@ -8,7 +8,7 @@
 
     {{ if .Params.abstract }}
     <h3>{{ i18n "abstract" }}</h3>
-    <p class="pub-abstract" itemprop="text">{{ .Params.abstract | markdownify }}</p>
+    <p class="pub-abstract">{{ .Params.abstract | markdownify }}</p>
     {{ end }}
 
     {{ if (.Params.publication_types) and (ne (index .Params.publication_types 0) "0") }}


### PR DESCRIPTION
### Microdata fixes

This fixes some of the microdata errors reported by [Google's microdata testing tool](https://search.google.com/structured-data/testing-tool)

Specifically:

- Publications are now marked as `ScholarlyArticle` instead of `CreativeWork`

- `itemprop=SameAs` added to DOI, indicating that publication here is the same as the publication at the corresponding DOI

- Each author in a publication or post is now marked as an individual person in microdata, instead of as a list.

- Fix space between comma and authors in case of multiple authors (remove newline in HTML that is rendered as a space between `<span>` tags)
