### PR TITLE
use fa-certificate when person declare it's a certificate and not a course

### DIFF
--- a/exampleSite/content/author/admin/_index.md
+++ b/exampleSite/content/author/admin/_index.md
@@ -34,6 +34,11 @@ user_groups = ["Researchers", "Visitors"]
 
 # List qualifications (such as academic degrees)
 [[education.courses]]
+  certificate = "IoT Interfaces and Biology"
+  institution = "Massachusetts Institute of Technology"
+  year = 2017
+
+[[education.courses]]
   course = "PhD in Artificial Intelligence"
   institution = "Stanford University"
   year = 2012

--- a/layouts/partials/widgets/about.html
+++ b/layouts/partials/widgets/about.html
@@ -94,11 +94,20 @@
         <ul class="ul-edu fa-ul">
           {{ range .courses }}
           <li>
+            {{ if .course }}
             <i class="fa-li fas fa-graduation-cap"></i>
             <div class="description">
               <p class="course">{{ .course }}{{ with .year }}, {{ . }}{{ end }}</p>
               <p class="institution">{{ .institution }}</p>
             </div>
+            {{ end }}
+            {{ if .certificate }}
+            <i class="fa-li fas fa-certificate"></i>
+            <div class="description">
+              <p class="course">{{ .certificate }}{{ with .year }}, {{ . }}{{ end }}</p>
+              <p class="institution">{{ .institution }}</p>
+            </div>
+            {{ end }}
           </li>
           {{ end }}
         </ul>


### PR DESCRIPTION
### Purpose

As I have many certification but not so many PhD; I though it would be nice to make a visual differentiation

So instead of 

```
[[education.courses]]
  course =
```

we could use

```
[[education.courses]]
  certificate =
```

![image](https://user-images.githubusercontent.com/5204724/53186799-fda7a380-3601-11e9-9819-78fdde428a3d.png)

### and the result is this

![image](https://user-images.githubusercontent.com/5204724/53186627-a4d80b00-3601-11e9-876b-1b6868743412.png)

### Documentation

will follow soon
