### PR TITLE
Fix JQuery exception when `day_night=true` and (`highlight=false` or `highlight_style` is set)

### DIFF
--- a/assets/js/academic.js
+++ b/assets/js/academic.js
@@ -307,19 +307,30 @@
   * --------------------------------------------------------------------------- */
 
   function toggleDarkMode() {
+    let light_sheet = $('link[title=hl-light]')[0];
+    let dark_sheet = $('link[title=hl-dark]')[0];
+
     if ($('body').hasClass('dark')) {
       $('body').css({opacity: 0, visibility: 'visible'}).animate({opacity: 1}, 500);
       $('body').removeClass('dark');
-      $('link[title=hl-light]')[0].disabled = false;
-      $('link[title=hl-dark]')[0].disabled = true;
+      if (light_sheet) {
+        light_sheet.disabled = true;
+      }
+      if (dark_sheet) {
+        dark_sheet.disabled = false;
+      }
       $('.js-dark-toggle i').removeClass('fa-sun');
       $('.js-dark-toggle i').addClass('fa-moon');
       localStorage.setItem('dark_mode', '0');
     } else {
       $('body').css({opacity: 0, visibility: 'visible'}).animate({opacity: 1}, 500);
       $('body').addClass('dark');
-      $('link[title=hl-light]')[0].disabled = true;
-      $('link[title=hl-dark]')[0].disabled = false;
+      if (light_sheet) {
+        light_sheet.disabled = false;
+      }
+      if (dark_sheet) {
+        dark_sheet.disabled = true;
+      }
       $('.js-dark-toggle i').removeClass('fa-moon');
       $('.js-dark-toggle i').addClass('fa-sun');
       localStorage.setItem('dark_mode', '1');
@@ -337,16 +348,28 @@
       default_mode = 1;
     }
     let dark_mode = parseInt(localStorage.getItem('dark_mode') || default_mode);
+
+    let light_sheet = $('link[title=hl-light]')[0];
+    let dark_sheet = $('link[title=hl-dark]')[0];
+
     if (dark_mode) {
       $('body').addClass('dark');
-      $('link[title=hl-light]')[0].disabled = true;
-      $('link[title=hl-dark]')[0].disabled = false;
+      if (light_sheet) {
+        light_sheet.disabled = true;
+      }
+      if (dark_sheet) {
+        dark_sheet.disabled = false;
+      }
       $('.js-dark-toggle i').removeClass('fa-moon');
       $('.js-dark-toggle i').addClass('fa-sun');
     } else {
       $('body').removeClass('dark');
-      $('link[title=hl-light]')[0].disabled = false;
-      $('link[title=hl-dark]')[0].disabled = true;
+      if (light_sheet) {
+        light_sheet.disabled = false;
+      }
+      if (dark_sheet) {
+        dark_sheet.disabled = true;
+      }
       $('.js-dark-toggle i').removeClass('fa-sun');
       $('.js-dark-toggle i').addClass('fa-moon');
     }

--- a/assets/js/academic.js
+++ b/assets/js/academic.js
@@ -306,33 +306,24 @@
   * Toggle day/night mode.
   * --------------------------------------------------------------------------- */
 
-  function toggleDarkMode() {
-    let light_sheet = $('link[title=hl-light]')[0];
-    let dark_sheet = $('link[title=hl-dark]')[0];
-
+  function toggleDarkMode(codeHlEnabled, codeHlLight, codeHlDark) {
     if ($('body').hasClass('dark')) {
       $('body').css({opacity: 0, visibility: 'visible'}).animate({opacity: 1}, 500);
       $('body').removeClass('dark');
-      if (light_sheet) {
-        light_sheet.disabled = true;
+      if (codeHlEnabled) {
+        codeHlLight.disabled = true;
+        codeHlDark.disabled = false;
       }
-      if (dark_sheet) {
-        dark_sheet.disabled = false;
-      }
-      $('.js-dark-toggle i').removeClass('fa-sun');
-      $('.js-dark-toggle i').addClass('fa-moon');
+      $('.js-dark-toggle i').removeClass('fa-sun').addClass('fa-moon');
       localStorage.setItem('dark_mode', '0');
     } else {
       $('body').css({opacity: 0, visibility: 'visible'}).animate({opacity: 1}, 500);
       $('body').addClass('dark');
-      if (light_sheet) {
-        light_sheet.disabled = false;
+      if (codeHlEnabled) {
+        codeHlLight.disabled = false;
+        codeHlDark.disabled = true;
       }
-      if (dark_sheet) {
-        dark_sheet.disabled = true;
-      }
-      $('.js-dark-toggle i').removeClass('fa-moon');
-      $('.js-dark-toggle i').addClass('fa-sun');
+      $('.js-dark-toggle i').removeClass('fa-moon').addClass('fa-sun');
       localStorage.setItem('dark_mode', '1');
     }
   }
@@ -349,30 +340,32 @@
     }
     let dark_mode = parseInt(localStorage.getItem('dark_mode') || default_mode);
 
-    let light_sheet = $('link[title=hl-light]')[0];
-    let dark_sheet = $('link[title=hl-dark]')[0];
+    // Is code highlighting enabled in site config?
+    const codeHlEnabled = $('link[title=hl-light]').length > 0;
+    const codeHlLight = $('link[title=hl-light]')[0];
+    const codeHlDark = $('link[title=hl-dark]')[0];
 
     if (dark_mode) {
       $('body').addClass('dark');
-      if (light_sheet) {
-        light_sheet.disabled = true;
+      if (codeHlEnabled) {
+        codeHlLight.disabled = true;
+        codeHlDark.disabled = false;
       }
-      if (dark_sheet) {
-        dark_sheet.disabled = false;
-      }
-      $('.js-dark-toggle i').removeClass('fa-moon');
-      $('.js-dark-toggle i').addClass('fa-sun');
+      $('.js-dark-toggle i').removeClass('fa-moon').addClass('fa-sun');
     } else {
       $('body').removeClass('dark');
-      if (light_sheet) {
-        light_sheet.disabled = false;
+      if (codeHlEnabled) {
+        codeHlLight.disabled = false;
+        codeHlDark.disabled = true;
       }
-      if (dark_sheet) {
-        dark_sheet.disabled = true;
-      }
-      $('.js-dark-toggle i').removeClass('fa-sun');
-      $('.js-dark-toggle i').addClass('fa-moon');
+      $('.js-dark-toggle i').removeClass('fa-sun').addClass('fa-moon');
     }
+
+    // Toggle day/night mode.
+    $('.js-dark-toggle').click(function(e) {
+      e.preventDefault();
+      toggleDarkMode(codeHlEnabled, codeHlLight, codeHlDark);
+    });
   });
 
   /* ---------------------------------------------------------------------------
@@ -512,12 +505,6 @@
         e.preventDefault();
         toggleSearchDialog();
       }
-    });
-
-    // Toggle day/night mode.
-    $('.js-dark-toggle').click(function(e) {
-      e.preventDefault();
-      toggleDarkMode();
     });
 
   });

--- a/assets/js/academic.js
+++ b/assets/js/academic.js
@@ -311,8 +311,8 @@
       $('body').css({opacity: 0, visibility: 'visible'}).animate({opacity: 1}, 500);
       $('body').removeClass('dark');
       if (codeHlEnabled) {
-        codeHlLight.disabled = true;
-        codeHlDark.disabled = false;
+        codeHlLight.disabled = false;
+        codeHlDark.disabled = true;
       }
       $('.js-dark-toggle i').removeClass('fa-sun').addClass('fa-moon');
       localStorage.setItem('dark_mode', '0');
@@ -320,8 +320,8 @@
       $('body').css({opacity: 0, visibility: 'visible'}).animate({opacity: 1}, 500);
       $('body').addClass('dark');
       if (codeHlEnabled) {
-        codeHlLight.disabled = false;
-        codeHlDark.disabled = true;
+        codeHlLight.disabled = true;
+        codeHlDark.disabled = false;
       }
       $('.js-dark-toggle i').removeClass('fa-moon').addClass('fa-sun');
       localStorage.setItem('dark_mode', '1');

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -6,7 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="generator" content="Source Themes Academic {{ .Site.Data.academic.version }}">
-  {{ .Hugo.Generator }}
 
   {{ $scr := .Scratch }}
 
@@ -14,7 +13,7 @@
   {{ $superuser_name := "" }}
   {{ $superuser_username := "" }}
   {{ $superuser_role := "" }}
-  {{ range first 1 (where (where $.Site.Pages "Section" "author") "Params.superuser" true) }}
+  {{ range first 1 (where (where site.Pages "Section" "author") "Params.superuser" true) }}
     {{ $superuser_name = .Params.name }}
     {{ $superuser_username = delimit (last 1 (split (substr .File.Dir 0 -1) "/")) "" }}
     {{ $superuser_role = .Params.role }}
@@ -74,7 +73,8 @@
     {{ if ($scr.Get "highlight_enabled") }}
       {{ $v := $css.highlight.version }}
       {{ with .Site.Params.highlight_style }}
-        {{ printf "<link rel=\"stylesheet\" href=\"%s\" crossorigin=\"anonymous\">" (printf $css.highlight.url $css.highlight.version .) | safeHTML }}
+        {{ printf "<link rel=\"stylesheet\" href=\"%s\" crossorigin=\"anonymous\" title=\"hl-light\">" (printf $css.highlight.url $css.highlight.version .) | safeHTML }}
+        {{ printf "<link rel=\"stylesheet\" href=\"%s\" crossorigin=\"anonymous\" title=\"hl-dark\" disabled>" (printf $css.highlight.url $css.highlight.version .) | safeHTML }}
       {{ else }}
         {{ if eq ($scr.Get "light") true }}
           {{ printf "<link rel=\"stylesheet\" href=\"%s\" crossorigin=\"anonymous\" title=\"hl-light\">" (printf $css.highlight.url $css.highlight.version "github") | safeHTML }}
@@ -133,9 +133,9 @@
   {{ end }}
   {{ end }}
 
-  {{ if or .Site.RSSLink .RSSLink }}
-  <link rel="alternate" href="{{ .RSSLink | default .Site.RSSLink  }}" type="application/rss+xml" title="{{ .Site.Title }}">
-  <link rel="feed" href="{{ .RSSLink | default .Site.RSSLink }}" type="application/rss+xml" title="{{ .Site.Title }}">
+  {{ with .OutputFormats.Get "RSS" }}
+  <link rel="alternate" href="{{ .RelPermalink }}" type="application/rss+xml" title="{{ site.Title }}">
+  <link rel="feed" href="{{ .RelPermalink }}" type="application/rss+xml" title="{{ site.Title }}">
   {{ end }}
 
   <link rel="manifest" href="{{ "site.webmanifest" | relURL }}">
@@ -154,7 +154,7 @@
   {{ else if .Site.Params.sharing_image }}
     {{ $og_image = printf "img/%s" .Site.Params.sharing_image | absURL }}
   {{ else if .Site.Params.avatar }}
-    {{ $og_image = (printf "img/%s" $.Site.Params.avatar) | absURL }}
+    {{ $og_image = (printf "img/%s" site.Params.avatar) | absURL }}
     {{ $twitter_card = "summary" }}
   {{ else }}
     {{ $og_image = "img/icon-192.png" | absURL }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="generator" content="Source Themes Academic {{ .Site.Data.academic.version }}">
+  {{ .Hugo.Generator }}
 
   {{ $scr := .Scratch }}
 
@@ -13,7 +14,7 @@
   {{ $superuser_name := "" }}
   {{ $superuser_username := "" }}
   {{ $superuser_role := "" }}
-  {{ range first 1 (where (where site.Pages "Section" "author") "Params.superuser" true) }}
+  {{ range first 1 (where (where $.Site.Pages "Section" "author") "Params.superuser" true) }}
     {{ $superuser_name = .Params.name }}
     {{ $superuser_username = delimit (last 1 (split (substr .File.Dir 0 -1) "/")) "" }}
     {{ $superuser_role = .Params.role }}
@@ -133,9 +134,9 @@
   {{ end }}
   {{ end }}
 
-  {{ with .OutputFormats.Get "RSS" }}
-  <link rel="alternate" href="{{ .RelPermalink }}" type="application/rss+xml" title="{{ site.Title }}">
-  <link rel="feed" href="{{ .RelPermalink }}" type="application/rss+xml" title="{{ site.Title }}">
+  {{ if or .Site.RSSLink .RSSLink }}
+  <link rel="alternate" href="{{ .RSSLink | default .Site.RSSLink  }}" type="application/rss+xml" title="{{ .Site.Title }}">
+  <link rel="feed" href="{{ .RSSLink | default .Site.RSSLink }}" type="application/rss+xml" title="{{ .Site.Title }}">
   {{ end }}
 
   <link rel="manifest" href="{{ "site.webmanifest" | relURL }}">
@@ -154,7 +155,7 @@
   {{ else if .Site.Params.sharing_image }}
     {{ $og_image = printf "img/%s" .Site.Params.sharing_image | absURL }}
   {{ else if .Site.Params.avatar }}
-    {{ $og_image = (printf "img/%s" site.Params.avatar) | absURL }}
+    {{ $og_image = (printf "img/%s" $.Site.Params.avatar) | absURL }}
     {{ $twitter_card = "summary" }}
   {{ else }}
     {{ $og_image = "img/icon-192.png" | absURL }}


### PR DESCRIPTION
### Purpose

If `highlight_style` is set in the `params.toml`, then the two style sheets aren't in the header. This causes an error, making it impossible to switch between light and dark mode permanently.

The issue was introduced in this commit: https://github.com/gcushen/hugo-academic/commit/34cf1f095700f3623a80c23c31d3e2172f7f7c1d#diff-df235be841d195af9df9944a9e319537