### PR TITLE
Fix citation view in publication widget

### DIFF
--- a/layouts/partials/widgets/pages.html
+++ b/layouts/partials/widgets/pages.html
@@ -79,7 +79,7 @@
         {{ partial "li_list" . }}
       {{ else if eq $st.Params.design.view 3 }}
         {{ partial "li_card" . }}
-      {{ else if eq $st.Params.design.view 3 | and (eq $st.Type "publication") }}
+      {{ else if eq $st.Params.design.view 4 | and (eq $items_type "publication") }}
         {{ partial "li_citation" . }}
       {{ else }}
         {{ partial "li_compact" . }}


### PR DESCRIPTION
### Purpose

I found the `design.view = 4` setting in the front matter of `content/home/publications.md` doesn't work. This commit will fix this issue.