### PR TITLE
Bugfix: missing the "see all posts" link on the posts widgets

### DIFF
--- a/layouts/partials/widgets/pages.html
+++ b/layouts/partials/widgets/pages.html
@@ -40,6 +40,8 @@
   {{ $query = where $query "Date" "<" now }}
 {{ end }}
 
+{{ $count := len $query }}
+
 {{/* Sort */}}
 {{ $sort_by := "Date" }}
 {{ $query = sort $query $sort_by $items_sort }}
@@ -50,8 +52,6 @@
 {{ else }}
   {{ $query = first $items_count $query }}
 {{ end }}
-
-{{ $count := len $query }}
 
 {{/* Localisation */}}
 {{ $i18n := "" }}


### PR DESCRIPTION
After the "Offset and Limit" section, `$query` would have length of `$items_count`, which makes `$count` always equal to `$items_count`. The later "if" condition for adding the "see all posts" link will never be met.

The fix is to record the length of `$query` into `$count` before any offset and limit.