### PR TITLE
Close Search Dialog on navbar menu dialog click.

### DIFF
--- a/assets/js/academic.js
+++ b/assets/js/academic.js
@@ -65,6 +65,10 @@
       // Prevent default click behavior.
       event.preventDefault();
 
+      if (isSearchDialogOpen()) {
+        closeSearchDialog();
+      }
+
       // Use jQuery's animate() method for smooth page scrolling.
       // The numerical parameter specifies the time (ms) taken to scroll to the specified hash.
       $('html, body').animate({
@@ -291,10 +295,18 @@
   * Toggle search dialog.
   * --------------------------------------------------------------------------- */
 
+  function isSearchDialogOpen() {
+    return $('body').hasClass('searching');
+  }
+
+  function closeSearchDialog() {
+    $('[id=search-query]').blur();
+    $('body').removeClass('searching');
+  }
+
   function toggleSearchDialog() {
-    if ($('body').hasClass('searching')) {
-      $('[id=search-query]').blur();
-      $('body').removeClass('searching');
+    if (isSearchDialogOpen()) {
+      closeSearchDialog();
     } else {
       $('body').addClass('searching');
       $('.search-results').css({opacity: 0, visibility: 'visible'}).animate({opacity: 1}, 200);


### PR DESCRIPTION
This allows navbar clicks to work as expected even when the search dialog is open.

### Purpose

Factor out logic to close the search dialog so that it can be reused to close it when users try to navigate away from search by clicking on any of the navbar links.

Fixes #996 