### PR TITLE
Adding default 'publishdate'.

### DIFF
--- a/archetypes/publication/index.md
+++ b/archetypes/publication/index.md
@@ -1,6 +1,7 @@
 +++
 title = "{{ replace .Name "-" " " | title }}"
 date = {{ .Date }}
+publishdate = {{ .Date }}
 
 # Authors. Comma separated list, e.g. `["Bob Smith", "David Jones"]`.
 authors = []

--- a/archetypes/publication/index.md
+++ b/archetypes/publication/index.md
@@ -1,7 +1,11 @@
 +++
 title = "{{ replace .Name "-" " " | title }}"
+
+# Publication date.
 date = {{ .Date }}
-publishdate = {{ .Date }}
+
+# Schedule page publish date.
+publishDate = {{ .Date }}
 
 # Authors. Comma separated list, e.g. `["Bob Smith", "David Jones"]`.
 authors = []


### PR DESCRIPTION
### Purpose

Adding default 'publishdate' to 'publication' archetype to allow publications further in the future to be shown by Hugo. Fixes #1023.