### PR TITLE
Fix people widget

### DIFF
--- a/layouts/partials/widgets/people.html
+++ b/layouts/partials/widgets/people.html
@@ -26,7 +26,7 @@
   {{ $avatar := (.Resources.ByType "image").GetMatch "*avatar*" }}
   {{/* Get link to user's profile page. */}}
   {{ $link := "" }}
-  {{ with site.GetPage (printf "/authors/%s" (path.Base (path.Split .Path).File.Dir)) }}
+  {{ with site.GetPage (printf "/authors/%s" (path.Base (path.Split .Path).Dir)) }}
     {{ $link = .RelPermalink }}
   {{ end }}
   <div class="col-12 col-sm-auto people-person">


### PR DESCRIPTION
### Purpose

This issue fixes a bug of people widget which is introduced in v4.2.2.

### How to reproduce the bug

1. Activate the people widget by changing `exampleSite/content/home/people.md`
2. Run `sh demo.sh` and you'll see

Error: Error building site: failed to render pages: render of "home" failed: execute of template failed: template: index.html:4:3: executing "index.html" at <partial "widget_page.html" .>: error calling partial: "/Users/seisman/Gits/academic-homepage/themes/academic/layouts/partials/widget_page.html:29:68": execute of template failed: template: partials/widget_page.html:65:9: executing "partials/widget_page.html" at <partial $widget_path $params>: error calling partial: "/Users/seisman/Gits/academic-homepage/themes/academic/layouts/partials/widgets/people.html:29:68": execute of template failed: template: partials/widgets/people.html:29:68: executing "partials/widgets/people.html" at <.Path>: can't evaluate field Dir in type string
