### PR TITLE
Adds rel-me to contact links

### DIFF
--- a/layouts/partials/widgets/contact.html
+++ b/layouts/partials/widgets/contact.html
@@ -96,7 +96,7 @@
       {{ if not $scheme }}
         {{ $link = .link | relLangURL }}
       {{ else if in (slice "http" "https") $scheme }}
-        {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
+        {{ $target = "target=\"_blank\" rel=\"noopener me\"" }}
       {{ end }}
       <li>
         <i class="fa-li {{ $pack }} {{ $pack_prefix }}-{{ .icon }} fa-2x" aria-hidden="true"></i>


### PR DESCRIPTION
### Purpose

[rel="me"](https://indieweb.org/rel-me) is a commonly used way to show that that two websites or social media accounts are the same, and is used for authentication and proving site ownership in a variety of ways. This PR adds this to all `http`/`https` contact links, piggybacking on the existing `noopener` value.

### Documentation

None should be required.