### PR TITLE
Fix #1055: list of authors missing on a publication page

### DIFF
--- a/layouts/partials/page_metadata.html
+++ b/layouts/partials/page_metadata.html
@@ -12,7 +12,7 @@
   {{ $authorLen := len $page.Params.authors }}
   {{ if gt $authorLen 0 }}
   <div>
-    {{ partial "page_metadata_authors" $ }}
+    {{ partial "page_metadata_authors" $page }}
   </div>
   {{ end }}
   {{ end }}


### PR DESCRIPTION
It seems that this place was not updated after some refactoring. As s result, the list of authors was missing from publication pages for example.

### Purpose

Fixes #1055