### PR TITLE
Minor change to German translation

### DIFF
--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -43,7 +43,7 @@
 - id: interests
   translation: Interessen
 - id: education
-  translation: Ausbildung
+  translation: Bildung
 - id: user_profile_latest
   translation: Aktuellste
 - id: see_certificate


### PR DESCRIPTION
Changed the German translation of "education" from "Ausbildung" to the more general "Bildung".
In my eyes "Ausbildung" refers to "training" (as in job training) and is less appropriate in academic contexts than "Bildung" (which is also education in the knowledge acquisition sense).
@DominikVogel, do you agree? 