### PR TITLE
Fixed social sharing button link issue

### DIFF
--- a/layouts/partials/page_metadata.html
+++ b/layouts/partials/page_metadata.html
@@ -68,7 +68,7 @@
   {{ end }}
 
   {{ if $share }}
-    {{ partial "share.html" $ }}
+    {{ partial "share.html" $page }}
   {{ end }}
 
 </div>


### PR DESCRIPTION
### Purpose
Social Sharing button's link didn't work as reported in the issue `#1116`. This request is to `Fix #1116 `.