### PR TITLE
i18n: Update French and Spanish translations

### DIFF
--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -17,7 +17,7 @@
 - id: figure
   translation: 'Figura %d:'
 - id: btn_preprint
-  translation: Preimpresión
+  translation: Prepublicación
 - id: btn_pdf
   translation: PDF
 - id: btn_cite
@@ -27,7 +27,7 @@
 - id: btn_video
   translation: Vídeo
 - id: btn_code
-  translation: Código
+  translation: Código fuente
 - id: btn_dataset
   translation: Datos
 - id: btn_project
@@ -45,13 +45,13 @@
 - id: education
   translation: Educación
 - id: user_profile_latest
-  translation: Latest
+  translation: Recientes
 - id: see_certificate
   translation: Ver certificado
 - id: present
   translation: Actualmente
 - id: more_pages
-  translation: See all
+  translation: Ver todo
 - id: more_posts
   translation: Más posts
 - id: more_talks
@@ -83,23 +83,23 @@
 - id: location
   translation: Localización
 - id: pub_uncat
-  translation: Uncategorized
+  translation: Sin categoría
 - id: pub_conf
-  translation: Conference paper
+  translation: Artículo de conferencia
 - id: pub_journal
-  translation: Journal article
+  translation: Artículo de revista
 - id: pub_preprint
-  translation: Preprint
+  translation: Prepublicación
 - id: pub_report
-  translation: Report
+  translation: Informe
 - id: pub_book
-  translation: Book
+  translation: Libro
 - id: pub_book_section
-  translation: Book section
+  translation: Capítulo de libro
 - id: pub_thesis
-  translation: Thesis
+  translation: Tesis
 - id: pub_patent
-  translation: Patent
+  translation: Patente
 - id: open_project_site
   translation: Ir al sitio del proyecto
 - id: posts
@@ -107,7 +107,7 @@
 - id: publications
   translation: Publicaciones
 - id: talks
-  translation: Conferencias
+  translation: Charlas
 - id: projects
   translation: Proyectos
 - id: search

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -17,7 +17,7 @@
 - id: figure
   translation: 'Figure %d:'
 - id: btn_preprint
-  translation: Prétirage
+  translation: Preprint
 - id: btn_pdf
   translation: PDF
 - id: btn_cite
@@ -45,13 +45,13 @@
 - id: education
   translation: Formation
 - id: user_profile_latest
-  translation: Latest
+  translation: Récents
 - id: see_certificate
-  translation: Voir certification
+  translation: Voir certificat
 - id: present
   translation: Actuellement
 - id: more_pages
-  translation: See all
+  translation: Voir tout
 - id: more_posts
   translation: Plus de posts
 - id: more_talks
@@ -61,7 +61,7 @@
 - id: contact_name
   translation: Nom
 - id: contact_email
-  translation: Email
+  translation: E-mail
 - id: contact_message
   translation: Message
 - id: contact_send
@@ -79,15 +79,15 @@
 - id: last_updated
   translation: Dernière mise à jour le
 - id: event
-  translation: Événement
+  translation: Évènement
 - id: location
   translation: Lieu
 - id: pub_uncat
   translation: Non catégorisé
 - id: pub_conf
-  translation: Document de conference
+  translation: Article de conférence
 - id: pub_journal
-  translation: Article de journal
+  translation: Article de revue
 - id: pub_preprint
   translation: Preprint
 - id: pub_report
@@ -95,11 +95,11 @@
 - id: pub_book
   translation: Livre
 - id: pub_book_section
-  translation: Section de livre
+  translation: Chapitre de livre
 - id: pub_thesis
-  translation: Thesis
+  translation: Thèse
 - id: pub_patent
-  translation: Patent
+  translation: Brevet
 - id: open_project_site
   translation: Aller sur le site du projet
 - id: posts


### PR DESCRIPTION
For French and Spanish translations:
- translated the few missing tokens
- corrected a few mistakes ("Preprint" = "Preprint" in French, "Prepublicación" in Spanish -- confirmed on Wikipedia)
- improved consistency ("Charlas" for "Talks" in Spanish, for all occurrences)