### PR TITLE
Add single column capabilities to many widgets

### DIFF
--- a/layouts/partials/widgets/accomplishments.html
+++ b/layouts/partials/widgets/accomplishments.html
@@ -1,13 +1,28 @@
 {{ $ := .root }}
 {{ $page := .page }}
+{{ $columns := $page.Params.design.columns | default "2" }}
 
 <!-- Accomplishments widget -->
 <div class="row">
-  <div class="col-12 col-lg-4 section-heading">
-    <h1>{{ with $page.Title }}{{ . | markdownify }}{{ end }}</h1>
-    {{ with $page.Params.subtitle }}<p>{{ . | markdownify }}</p>{{ end }}
+  {{ if ne $columns "1" }}
+  <div class="col-12 col-lg-4">
+    <div class="section-heading academic-widget-two-column">
+      {{ with $page.Title }}<h1>{{ . | markdownify | emojify }}</h1>{{ end }}
+      {{ with $page.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
+    </div>
   </div>
   <div class="col-12 col-lg-8">
+
+  {{ else }}
+  <div class="col-lg-12">
+    <div class="section-heading academic-widget-one-column">
+      {{ with $page.Title }}<h1>{{ . | markdownify | emojify }}</h1>{{ end }}
+      {{ with $page.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
+    </div>
+  {{ end }}
+
+    {{ $page.Content }}
+
     {{ with $page.Content }}<p>{{ . | markdownify }}</p>{{ end }}
 
     {{ if $page.Params.item }}

--- a/layouts/partials/widgets/blank.html
+++ b/layouts/partials/widgets/blank.html
@@ -3,18 +3,22 @@
 
 <div class="row">
   {{ if ne $columns "1" }}
-    <div class="col-12 col-lg-4 section-heading">
+  <div class="col-12 col-lg-4">
+    <div class="section-heading academic-widget-two-column">
       {{ with $st.Title }}<h1>{{ . | markdownify | emojify }}</h1>{{ end }}
       {{ with $st.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
     </div>
-    <div class="col-12 col-lg-8">
-      {{ $st.Content }}
-    </div>
+  </div>
+  <div class="col-12 col-lg-8">
+
   {{ else }}
-    <div class="col-lg-12">
+  <div class="col-lg-12">
+    <div class="section-heading academic-widget-one-column">
       {{ with $st.Title }}<h1>{{ . | markdownify | emojify }}</h1>{{ end }}
       {{ with $st.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
-      {{ $st.Content }}
     </div>
   {{ end }}
+
+    {{ $st.Content }}
+  </div>
 </div>

--- a/layouts/partials/widgets/contact.html
+++ b/layouts/partials/widgets/contact.html
@@ -1,14 +1,27 @@
 {{ $ := .root }}
 {{ $page := .page }}
 {{ $autolink := default true $page.Params.autolink }}
+{{ $columns := $page.Params.design.columns | default "2" }}
 
 <!-- Contact widget -->
 <div class="row contact-widget">
-  <div class="col-12 col-lg-4 section-heading">
-    <h1>{{ with $page.Title }}{{ . | markdownify }}{{ end }}</h1>
-    {{ with $page.Params.subtitle }}<p>{{ . | markdownify }}</p>{{ end }}
+  {{ if ne $columns "1" }}
+  <div class="col-12 col-lg-4">
+    <div class="section-heading academic-widget-two-column">
+      {{ with $page.Title }}<h1>{{ . | markdownify | emojify }}</h1>{{ end }}
+      {{ with $page.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
+    </div>
   </div>
   <div class="col-12 col-lg-8">
+
+  {{ else }}
+  <div class="col-lg-12">
+    <div class="section-heading academic-widget-one-column">
+      {{ with $page.Title }}<h1>{{ . | markdownify | emojify }}</h1>{{ end }}
+      {{ with $page.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
+    </div>
+  {{ end }}
+
     {{ with $page.Content }}<p>{{ . | markdownify }}</p>{{ end }}
 
     {{ if $page.Params.email_form }}

--- a/layouts/partials/widgets/experience.html
+++ b/layouts/partials/widgets/experience.html
@@ -1,13 +1,26 @@
 {{ $ := .root }}
 {{ $page := .page }}
+{{ $columns := $page.Params.design.columns | default "2" }}
 
 <!-- Experience widget -->
-<div class="row">
-  <div class="col-12 col-lg-4 section-heading">
-    <h1>{{ with $page.Title }}{{ . | markdownify }}{{ end }}</h1>
-    {{ with $page.Params.subtitle }}<p>{{ . | markdownify }}</p>{{ end }}
+<div class="row contact-widget">
+  {{ if ne $columns "1" }}
+  <div class="col-12 col-lg-4">
+    <div class="section-heading academic-widget-two-column">
+      {{ with $page.Title }}<h1>{{ . | markdownify | emojify }}</h1>{{ end }}
+      {{ with $page.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
+    </div>
   </div>
   <div class="col-12 col-lg-8">
+
+  {{ else }}
+  <div class="col-lg-12">
+    <div class="section-heading academic-widget-one-column">
+      {{ with $page.Title }}<h1>{{ . | markdownify | emojify }}</h1>{{ end }}
+      {{ with $page.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
+    </div>
+  {{ end }}
+
     {{ with $page.Content }}<p>{{ . | markdownify }}</p>{{ end }}
 
     {{ if $page.Params.experience }}

--- a/layouts/partials/widgets/featured.html
+++ b/layouts/partials/widgets/featured.html
@@ -31,12 +31,25 @@
 {{/* Limit */}}
 {{ $query = first $items_count $query }}
 
+{{ $columns := $st.Params.design.columns | default "2" }}
+
 <div class="row">
-  <div class="col-12 col-lg-4 section-heading">
-    <h1>{{ with $st.Title }}{{ . | markdownify | emojify }}{{ end }}</h1>
-    {{ with $st.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
+  {{ if ne $columns "1" }}
+  <div class="col-12 col-lg-4">
+    <div class="section-heading academic-widget-two-column">
+      {{ with $st.Title }}<h1>{{ . | markdownify | emojify }}</h1>{{ end }}
+      {{ with $st.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
+    </div>
   </div>
   <div class="col-12 col-lg-8">
+
+  {{ else }}
+  <div class="col-lg-12">
+    <div class="section-heading academic-widget-one-column">
+      {{ with $st.Title }}<h1>{{ . | markdownify | emojify }}</h1>{{ end }}
+      {{ with $st.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
+    </div>
+  {{ end }}
 
     {{ with $st.Content }}<p>{{ . }}</p>{{ end }}
 

--- a/layouts/partials/widgets/pages.html
+++ b/layouts/partials/widgets/pages.html
@@ -65,12 +65,25 @@
   {{ $i18n = "more_pages" }}
 {{ end }}
 
+{{ $columns := $st.Params.design.columns | default "2" }}
+
 <div class="row">
-  <div class="col-12 col-lg-4 section-heading">
-    <h1>{{ with $st.Title }}{{ . | markdownify | emojify }}{{ end }}</h1>
-    {{ with $st.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
+  {{ if ne $columns "1" }}
+  <div class="col-12 col-lg-4">
+    <div class="section-heading academic-widget-two-column">
+      {{ with $st.Title }}<h1>{{ . | markdownify | emojify }}</h1>{{ end }}
+      {{ with $st.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
+    </div>
   </div>
   <div class="col-12 col-lg-8">
+
+  {{ else }}
+  <div class="col-lg-12">
+    <div class="section-heading academic-widget-one-column">
+      {{ with $st.Title }}<h1>{{ . | markdownify | emojify }}</h1>{{ end }}
+      {{ with $st.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
+    </div>
+  {{ end }}
 
     {{ with $st.Content }}<p>{{ . }}</p>{{ end }}
 

--- a/layouts/partials/widgets/portfolio.html
+++ b/layouts/partials/widgets/portfolio.html
@@ -10,13 +10,13 @@
 {{/* Standard dual-column layout. */}}
 
 <div class="row">
-  <div class="col-xs-12 col-md-4 section-heading">
+  <div class="col-12 col-lg-4 section-heading">
 
     {{ with $st.Title }}<h1>{{ . | markdownify | emojify }}</h1>{{ end }}
     {{ with $st.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
 
   </div>
-  <div class="col-xs-12 col-md-8">
+  <div class="col-12 col-lg-8">
 
 {{ else }}
 {{/* Single column layout. */}}

--- a/layouts/partials/widgets/portfolio.html
+++ b/layouts/partials/widgets/portfolio.html
@@ -6,29 +6,25 @@
 {{ $items_type := $st.Params.content.page_type | default "project" }}
 {{ $columns := $st.Params.design.columns | default "2" }}
 
-{{ if ne $columns "1" }}
 {{/* Standard dual-column layout. */}}
 
 <div class="row">
-  <div class="col-12 col-lg-4 section-heading">
-
-    {{ with $st.Title }}<h1>{{ . | markdownify | emojify }}</h1>{{ end }}
-    {{ with $st.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
-
+  {{ if ne $columns "1" }}
+  <div class="col-12 col-lg-4">
+    <div class="section-heading academic-widget-two-column">
+      {{ with $st.Title }}<h1>{{ . | markdownify | emojify }}</h1>{{ end }}
+      {{ with $st.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
+    </div>
   </div>
   <div class="col-12 col-lg-8">
 
-{{ else }}
-{{/* Single column layout. */}}
-
-<div class="margin-auto">
-
-  <div class="center-text">
-    {{ with $st.Title }}<h1 class="mt-0">{{ . | markdownify | emojify }}</h1>{{ end }}
-    {{ with $st.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
-  </div>
-  <div>
-{{ end }}
+  {{ else }}
+  <div class="col-lg-12">
+    <div class="section-heading academic-widget-one-column">
+      {{ with $st.Title }}<h1>{{ . | markdownify | emojify }}</h1>{{ end }}
+      {{ with $st.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
+    </div>
+  {{ end }}
 
     {{ with $st.Content }}<p>{{ . }}</p>{{ end }}
 

--- a/layouts/partials/widgets/tag_cloud.html
+++ b/layouts/partials/widgets/tag_cloud.html
@@ -1,12 +1,25 @@
 {{ $ := .root }}
 {{ $page := .page }}
+{{ $columns := $page.Params.design.columns | default "2" }}
 
 <div class="row">
-  <div class="col-12 col-lg-4 section-heading">
-    <h1>{{ with $page.Title }}{{ . | markdownify | emojify }}{{ end }}</h1>
-    {{ with $page.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
+  {{ if ne $columns "1" }}
+  <div class="col-12 col-lg-4">
+    <div class="section-heading academic-widget-two-column">
+      {{ with $page.Title }}<h1>{{ . | markdownify | emojify }}</h1>{{ end }}
+      {{ with $page.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
+    </div>
   </div>
   <div class="col-12 col-lg-8">
+
+  {{ else }}
+  <div class="col-lg-12">
+    <div class="section-heading academic-widget-one-column">
+      {{ with $page.Title }}<h1>{{ . | markdownify | emojify }}</h1>{{ end }}
+      {{ with $page.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
+    </div>
+  {{ end }}
+
     {{ with $page.Content }}<p>{{ . }}</p>{{ end }}
 
     {{ if not (eq (len site.Taxonomies.tags) 0) }}


### PR DESCRIPTION
### Purpose

This partially addresses #984.  A few widgets (about, featurette, hero, people, slider) are not updated.

It also separates the title and subtitles (section heading) into a separate dive so that one and two column modes can have different styling.

### Thoughts
* This may not be ready for merge, pending further updates and discussion.
* About could be done in this style too.
* The projects widget was not consistent, with respect to bootstrap media breakpoints, so this bring that in line.  If that difference was deliberate, the changes can be reverted.
* The two-column class could be added to the titles of the 5 untouched widgets.
* It does not make much sense to one-column, the featurette and slider.
* I don't have enough info/experience to decide to how best to handle the hero and people cases. 