### PR TITLE
isolated fancybox styling to the gallery shortcode

### DIFF
--- a/assets/sass/academic/_root.scss
+++ b/assets/sass/academic/_root.scss
@@ -276,7 +276,7 @@ small,
   font-size: 0;
 }
 
-.gallery a[data-fancybox] {
+a[data-fancybox] {
   text-decoration: none;
 }
 

--- a/assets/sass/academic/_root.scss
+++ b/assets/sass/academic/_root.scss
@@ -276,11 +276,11 @@ small,
   font-size: 0;
 }
 
-a[data-fancybox] {
+.gallery a[data-fancybox] {
   text-decoration: none;
 }
 
-a[data-fancybox] img {
+.gallery a[data-fancybox] img {
   height: 250px;
   max-width: inherit;
   display: inherit;


### PR DESCRIPTION
### Purpose

Currently, the gallery fancybox styling styles all fancybox instances, which requires extra CSS every time I want to use it.

This PR isolates the fancybox styling to the gallery shortcode.