### PR TITLE
feat: added lightbox option to figure shortcode

### DIFF
--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -3,10 +3,17 @@
 {{ if .Get "library" }}
   {{ $image_src = printf "img/%s" $image_src | relURL }}
 {{ end }}
+{{ $lightbox := eq (.Get "lightbox" | default "false") "true" }}
+{{ $group := .Get "lightbox-group" | default "figures" }}
+
 <figure{{ with .Get "class" }} class="{{.}}"{{ end }}>
-{{ if .Get "link"}}<a href="{{ .Get "link" }}"{{ with .Get "target" }} target="{{ . }}"{{ end }}{{ with .Get "rel" }} rel="{{ . }}"{{ end }}>{{ end }}
+{{ if $lightbox }}
+  <a data-fancybox="{{ $group }}" data-src="{{ $image_src }}" href="javascript:;" {{ with .Get "caption"}}data-caption="{{ . | markdownify | emojify }}"{{ end }}>
+{{ else if .Get "link"}}
+  <a href="{{ .Get "link" }}"{{ with .Get "target" }} target="{{ . }}"{{ end }}{{ with .Get "rel" }} rel="{{ . }}"{{ end }}>
+{{ end }}
 <img src="{{ $image_src }}" {{ if or (.Get "alt") (.Get "caption") }}alt="{{ with .Get "alt"}}{{.}}{{else}}{{ .Get "caption" }}{{ end }}" {{ end }}{{ with .Get "width" }}width="{{.}}" {{ end }}{{ with .Get "height" }}height="{{.}}" {{ end }}/>
-{{ if .Get "link"}}</a>{{ end }}
+{{ if or $lightbox (.Get "link") }}</a>{{ end }}
 {{ if or (or (.Get "title") (.Get "caption")) (.Get "attr")}}
 {{ $figure := split (i18n "figure" | default "Figure %d:") "%d" }}
 <figcaption data-pre="{{ index $figure 0 }}" data-post="{{ index $figure 1 }}" {{ if eq (.Get "numbered") "true" }}class="numbered"{{ end }}>

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -4,15 +4,15 @@
   {{ $image_src = printf "img/%s" $image_src | relURL }}
 {{ end }}
 {{ $lightbox := eq (.Get "lightbox" | default "false") "true" }}
-{{ $group := .Get "lightbox-group" | default "figures" }}
+{{ $group := .Get "lightbox-group" | default "" }}
 
 <figure{{ with .Get "class" }} class="{{.}}"{{ end }}>
 {{ if $lightbox }}
-  <a data-fancybox="{{ $group }}" data-src="{{ $image_src }}" href="javascript:;" {{ with .Get "caption"}}data-caption="{{ . | markdownify | emojify }}"{{ end }}>
+  <a data-fancybox="{{$group}}" href="{{$image_src}}" {{ with .Get "caption"}}data-caption="{{ .|markdownify|emojify }}"{{ end }}>
 {{ else if .Get "link"}}
-  <a href="{{ .Get "link" }}"{{ with .Get "target" }} target="{{ . }}"{{ end }}{{ with .Get "rel" }} rel="{{ . }}"{{ end }}>
+  <a href="{{ .Get "link" }}"{{ with .Get "target" }} target="{{.}}"{{ end }}{{ with .Get "rel" }} rel="{{.}}"{{ end }}>
 {{ end }}
-<img src="{{ $image_src }}" {{ if or (.Get "alt") (.Get "caption") }}alt="{{ with .Get "alt"}}{{.}}{{else}}{{ .Get "caption" }}{{ end }}" {{ end }}{{ with .Get "width" }}width="{{.}}" {{ end }}{{ with .Get "height" }}height="{{.}}" {{ end }}/>
+<img src="{{$image_src}}" {{ if or (.Get "alt") (.Get "caption") }}alt="{{ with .Get "alt"}}{{.}}{{else}}{{ .Get "caption" }}{{ end }}" {{ end }}{{ with .Get "width" }}width="{{.}}" {{ end }}{{ with .Get "height" }}height="{{.}}" {{ end }}>
 {{ if or $lightbox (.Get "link") }}</a>{{ end }}
 {{ if or (or (.Get "title") (.Get "caption")) (.Get "attr")}}
 {{ $figure := split (i18n "figure" | default "Figure %d:") "%d" }}


### PR DESCRIPTION
### Purpose

This PR adds an option to the figure shortcode to embed the figure into the fancybox lightbox.

To enable, use:

    {{< figure src="example.png" lightbox="true" >}}

The lightbox variable being unset and any value other than "true" is equivalent to false.  The caption field is embedded in the lightbox caption.

To change the lightbox group, set `lightbox-group="example"`.  Default group is "figures".

Note, it will make more sense, CSS style wise, for this to merge after #1145.