### PR TITLE
fix: icon in slider widget only works for fa icon pack

### DIFF
--- a/layouts/partials/li_card.html
+++ b/layouts/partials/li_card.html
@@ -64,7 +64,7 @@
   {{end}}
 
   <h3 class="article-title mb-1 mt-3" itemprop="name">
-    <a href="{{ $item.RelPermalink }}" itemprop="url">{{ $item.Title }}</a>
+    <a href="{{ $item.RelPermalink }}" itemprop="url">{{ $item.Title | markdownify | emojify }}</a>
   </h3>
 
   {{ with $summary }}

--- a/layouts/partials/li_citation.html
+++ b/layouts/partials/li_citation.html
@@ -8,7 +8,7 @@
     {{ partial "page_metadata_authors" . }}
   </span>
   ({{- .Date.Format "2006" -}}).
-  <a href="{{ .RelPermalink }}" itemprop="name">{{ .Title }}</a>.
+  <a href="{{ .RelPermalink }}" itemprop="name">{{ .Title | markdownify | emojify }}</a>.
   {{ if .Params.publication_short }}
   {{- .Params.publication_short | markdownify -}}.
   {{ else if .Params.publication }}
@@ -22,7 +22,7 @@
   <span itemprop="author" class="article-metadata li-cite-author">
     {{ partial "page_metadata_authors" . }}
   </span>.
-  <a href="{{ .RelPermalink }}" itemprop="name">{{ .Title }}</a>.
+  <a href="{{ .RelPermalink }}" itemprop="name">{{ .Title | markdownify | emojify }}</a>.
   {{ if .Params.publication_short }}
   {{- .Params.publication_short | markdownify -}},
   {{ else if .Params.publication }}

--- a/layouts/partials/li_compact.html
+++ b/layouts/partials/li_compact.html
@@ -31,7 +31,7 @@
   <div class="media-body">
 
     <h3 class="article-title mb-0 mt-0" itemprop="name">
-      <a href="{{ $item.RelPermalink }}" itemprop="url">{{ $item.Title }}</a>
+      <a href="{{ $item.RelPermalink }}" itemprop="url">{{ $item.Title | markdownify | emojify }}</a>
     </h3>
 
     {{ with $summary }}

--- a/layouts/partials/li_list.html
+++ b/layouts/partials/li_list.html
@@ -20,7 +20,7 @@
 
 <div class="view-list-item" itemscope itemtype="http://schema.org/{{$microdata_type}}">
   <i class="far {{$icon}} pub-icon" aria-hidden="true"></i>
-  <a href="{{ $item.RelPermalink }}" itemprop="url"><span itemprop="name">{{ $item.Title }}</span></a>
+  <a href="{{ $item.RelPermalink }}" itemprop="url"><span itemprop="name">{{ $item.Title | markdownify | emojify }}</span></a>
 
   {{ if eq $item.Type "talk" }}
   <div class="article-metadata">

--- a/layouts/partials/page_header.html
+++ b/layouts/partials/page_header.html
@@ -53,7 +53,7 @@
 {{end}}
 
 <div class="article-container pt-3">
-  <h1 itemprop="name">{{ $title }}</h1>
+  <h1 itemprop="name">{{ $title | markdownify | emojify }}</h1>
 
   {{ with $page.Params.subtitle }}
   <p class="page-subtitle">{{ . | markdownify | emojify }}</p>
@@ -79,7 +79,7 @@
     {{ $ctnr = "universal-wrapper" }}
   {{end}}
 <div class="{{$ctnr}} pt-3">
-  <h1 itemprop="name">{{ $title }}</h1>
+  <h1 itemprop="name">{{ $title | markdownify | emojify }}</h1>
 
   {{ with $page.Params.subtitle }}
   <p class="page-subtitle">{{ . | markdownify | emojify }}</p>

--- a/layouts/partials/widgets/slider.html
+++ b/layouts/partials/widgets/slider.html
@@ -34,10 +34,14 @@
         {{ end }}
 
         {{ if $item.cta_url }}
-        {{ $pack := or .icon_pack "fa" }}
+        {{ $pack := or .cta_icon_pack "fa" }}
+        {{ $pack_prefix := $pack }}
+        {{ if in (slice "fab" "fas" "far" "fal") $pack }}
+          {{ $pack_prefix = "fa" }}
+        {{ end }}
         <p>
           <a href="{{ $item.cta_url }}" class="btn btn-light btn-lg">
-            {{- with $item.cta_icon -}}<i class="{{ $pack }} {{ $pack }}-{{ . }}" style="padding-right: 10px;"></i>{{- end -}}
+            {{- with $item.cta_icon -}}<i class="{{ $pack }} {{ $pack_prefix }}-{{ . }}" style="padding-right: 10px;"></i>{{- end -}}
             {{- $item.cta_label | emojify | safeHTML -}}
           </a>
         </p>


### PR DESCRIPTION
### Purpose

The icon class in the slider widget is constructed using
`"{{ $pack }} {{ $pack }}-{{ . }}"` with double `$pack` prefix and
therefore only works for `fa fa-*` icons.

Example: The github icon in the `fab` icon pack is not supported:

```none
cta_icon_pack = "fab"
cta_icon = "github"
```

### Screenshots

Before:
![Screenshot 2019-07-06 at 15 44 18](https://user-images.githubusercontent.com/8161292/60757010-1ccd2d80-a005-11e9-98f7-c4275af5099c.png)

After:
![Screenshot 2019-07-06 at 15 44 09](https://user-images.githubusercontent.com/8161292/60757012-222a7800-a005-11e9-807a-4022f4b460f8.png)


### Documentation

Solution: Conditionally detect `$pack_prefix` as done in the about widget [here](https://github.com/gcushen/hugo-academic/blob/263926cc45ab566f8889e9fd4c4b5f42adfd9f1d/layouts/partials/widgets/about.html#L50)
