### PR TITLE
fix: icon in slider widget only works for fa icon pack

### DIFF
--- a/layouts/partials/widgets/slider.html
+++ b/layouts/partials/widgets/slider.html
@@ -34,7 +34,7 @@
         {{ end }}
 
         {{ if $item.cta_url }}
-        {{ $pack := or .cta_icon_pack "fa" }}
+        {{ $pack := or .cta_icon_pack "fas" }}
         {{ $pack_prefix := $pack }}
         {{ if in (slice "fab" "fas" "far" "fal") $pack }}
           {{ $pack_prefix = "fa" }}

--- a/layouts/partials/widgets/slider.html
+++ b/layouts/partials/widgets/slider.html
@@ -34,10 +34,14 @@
         {{ end }}
 
         {{ if $item.cta_url }}
-        {{ $pack := or .icon_pack "fa" }}
+        {{ $pack := or .cta_icon_pack "fa" }}
+        {{ $pack_prefix := $pack }}
+        {{ if in (slice "fab" "fas" "far" "fal") $pack }}
+          {{ $pack_prefix = "fa" }}
+        {{ end }}
         <p>
           <a href="{{ $item.cta_url }}" class="btn btn-light btn-lg">
-            {{- with $item.cta_icon -}}<i class="{{ $pack }} {{ $pack }}-{{ . }}" style="padding-right: 10px;"></i>{{- end -}}
+            {{- with $item.cta_icon -}}<i class="{{ $pack }} {{ $pack_prefix }}-{{ . }}" style="padding-right: 10px;"></i>{{- end -}}
             {{- $item.cta_label | emojify | safeHTML -}}
           </a>
         </p>


### PR DESCRIPTION
### Purpose

The icon class in the slider widget is constructed using
`"{{ $pack }} {{ $pack }}-{{ . }}"` with double `$pack` prefix and
therefore only works for `fa fa-*` icons.

Example: The github icon in the `fab` icon pack is not supported:

```none
cta_icon_pack = "fab"
cta_icon = "github"
```

### Screenshots

Before:
![Screenshot 2019-07-06 at 15 44 18](https://user-images.githubusercontent.com/8161292/60757010-1ccd2d80-a005-11e9-98f7-c4275af5099c.png)

After:
![Screenshot 2019-07-06 at 15 44 09](https://user-images.githubusercontent.com/8161292/60757012-222a7800-a005-11e9-807a-4022f4b460f8.png)


### Documentation

Solution: Conditionally detect `$pack_prefix` as done in the about widget [here](https://github.com/gcushen/hugo-academic/blob/263926cc45ab566f8889e9fd4c4b5f42adfd9f1d/layouts/partials/widgets/about.html#L50)