### PR TITLE
Remove paragraph wrapping portfolio widget content.

### DIFF
--- a/layouts/partials/widgets/accomplishments.html
+++ b/layouts/partials/widgets/accomplishments.html
@@ -8,7 +8,7 @@
     {{ with $page.Params.subtitle }}<p>{{ . | markdownify }}</p>{{ end }}
   </div>
   <div class="col-12 col-lg-8">
-    {{ with $page.Content }}<p>{{ . | markdownify }}</p>{{ end }}
+    {{ with $page.Content }}{{ . }}{{ end }}
 
     {{ if $page.Params.item }}
     {{ range $idx, $key := sort $page.Params.item ".date_start" "desc" }}

--- a/layouts/partials/widgets/contact.html
+++ b/layouts/partials/widgets/contact.html
@@ -9,7 +9,7 @@
     {{ with $page.Params.subtitle }}<p>{{ . | markdownify }}</p>{{ end }}
   </div>
   <div class="col-12 col-lg-8">
-    {{ with $page.Content }}<p>{{ . | markdownify }}</p>{{ end }}
+    {{ with $page.Content }}{{ . }}{{ end }}
 
     {{ if $page.Params.email_form }}
 

--- a/layouts/partials/widgets/experience.html
+++ b/layouts/partials/widgets/experience.html
@@ -8,7 +8,7 @@
     {{ with $page.Params.subtitle }}<p>{{ . | markdownify }}</p>{{ end }}
   </div>
   <div class="col-12 col-lg-8">
-    {{ with $page.Content }}<p>{{ . | markdownify }}</p>{{ end }}
+    {{ with $page.Content }}{{ . }}{{ end }}
 
     {{ if $page.Params.experience }}
     {{ $exp_len := len $page.Params.experience }}

--- a/layouts/partials/widgets/featured.html
+++ b/layouts/partials/widgets/featured.html
@@ -38,7 +38,7 @@
   </div>
   <div class="col-12 col-lg-8">
 
-    {{ with $st.Content }}<p>{{ . }}</p>{{ end }}
+    {{ with $st.Content }}{{ . }}{{ end }}
 
     {{ range $post := $query }}
       {{ if eq $st.Params.design.view 1 }}

--- a/layouts/partials/widgets/featurette.html
+++ b/layouts/partials/widgets/featurette.html
@@ -11,7 +11,7 @@
 
   {{ with $page.Content }}
   <div class="col-md-12">
-    <p>{{ . | markdownify }}</p>
+    {{ . }}
   </div>
   {{ end }}
 

--- a/layouts/partials/widgets/pages.html
+++ b/layouts/partials/widgets/pages.html
@@ -72,7 +72,7 @@
   </div>
   <div class="col-12 col-lg-8">
 
-    {{ with $st.Content }}<p>{{ . }}</p>{{ end }}
+    {{ with $st.Content }}{{ . }}{{ end }}
 
     {{ range $post := $query }}
       {{ if eq $st.Params.design.view 1 }}

--- a/layouts/partials/widgets/people.html
+++ b/layouts/partials/widgets/people.html
@@ -11,7 +11,7 @@
 
   {{ with $page.Content }}
   <div class="col-md-12">
-    <p>{{ . }}</p>
+    {{ . }}
   </div>
   {{ end }}
 

--- a/layouts/partials/widgets/portfolio.html
+++ b/layouts/partials/widgets/portfolio.html
@@ -30,7 +30,7 @@
   <div>
 {{ end }}
 
-    {{ with $st.Content }}<p>{{ . }}</p>{{ end }}
+    {{ with $st.Content }}{{ . }}{{ end }}
 
     {{ if $st.Params.content.filter_button }}
 

--- a/layouts/partials/widgets/tag_cloud.html
+++ b/layouts/partials/widgets/tag_cloud.html
@@ -7,7 +7,7 @@
     {{ with $page.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
   </div>
   <div class="col-12 col-lg-8">
-    {{ with $page.Content }}<p>{{ . }}</p>{{ end }}
+    {{ with $page.Content }}{{ . }}{{ end }}
 
     {{ if not (eq (len site.Taxonomies.tags) 0) }}
       {{ $fontSmall := 0.8 }}


### PR DESCRIPTION
### Purpose

If the portfolio widget page has content defined, blackfriday will
render it as markdown, wrapping text in `<p>` tags.
Wrapping the content in additional paragraph tags will cause the
resulting output to look like the following, which is invalid HTML

```
<p>
  <p>First paragraph</p>
  <p>Another paragraph</p>
</p>
```

(Paragraphs can't be nested)

To reproduce this in the example site, just add a couple paragraph to the portfolio widget page.