### PR TITLE
Attempt to show comments on relevant page types.

### DIFF
--- a/layouts/partials/page_metadata.html
+++ b/layouts/partials/page_metadata.html
@@ -49,7 +49,7 @@
   </span>
   {{ end }}
 
-  {{ $comments_enabled := and site.DisqusShortname (not (or site.Params.disable_comments (eq $page.Params.comments false))) }}
+  {{ $comments_enabled := and site.DisqusShortname (in (slice "post" "page") $page.Type) (not (or site.Params.disable_comments (eq $page.Params.comments false))) }}
   {{ if and $comments_enabled (site.Params.comment_count | default true) }}
   <span class="middot-divider"></span>
   <a href="{{ $page.RelPermalink }}#disqus_thread"><!-- Count will be inserted here --></a>


### PR DESCRIPTION
### Purpose

Address the fact that we are trying to insert markdown to support disqus comment count links even on pages that do not support comments.
Fixes #1192.