### PR TITLE
Fix omitted URL scheme

### DIFF
--- a/layouts/partials/cookie_consent.html
+++ b/layouts/partials/cookie_consent.html
@@ -1,7 +1,7 @@
 {{ if site.Params.privacy_pack }}
 {{ $scr := .Scratch }}
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.css">
-<script src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.js"></script>
 <script>
   window.addEventListener("load", function(){
     window.cookieconsent.initialise({

--- a/layouts/partials/site_head.html
+++ b/layouts/partials/site_head.html
@@ -127,7 +127,7 @@
       ga('require', 'urlChangeTracker');
       ga('send', 'pageview');
     </script>
-    <script async src="//www.google-analytics.com/analytics.js"></script>
+    <script async src="https://www.google-analytics.com/analytics.js"></script>
     {{ if ($scr.Get "use_cdn") }}
     {{ printf "<script async src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" (printf $js.autotrack.url $js.autotrack.version) $js.autotrack.sri | safeHTML }}
     {{ end }}

--- a/layouts/partials/site_js.html
+++ b/layouts/partials/site_js.html
@@ -24,7 +24,7 @@
         {{ $v := $js.highlight.version }}
         {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" (printf $js.highlight.url $v) $js.highlight.sri | safeHTML }}
         {{ range site.Params.highlight_languages }}
-        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/{{ $v }}/languages/{{ . }}.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/{{ $v }}/languages/{{ . }}.min.js"></script>
         {{ end }}
       {{ end }}
 
@@ -36,7 +36,7 @@
 
     {{/* Maps JS. */}}
     {{ if eq site.Params.map 1 }}
-      <script async defer src="//maps.googleapis.com/maps/api/js?key={{ site.Params.map_api_key }}"></script>
+      <script async defer src="https://maps.googleapis.com/maps/api/js?key={{ site.Params.map_api_key }}"></script>
       {{ if ($scr.Get "use_cdn") }}
       {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" (printf $js.gmaps.url $js.gmaps.version) $js.gmaps.sri | safeHTML }}
       {{ end }}
@@ -47,7 +47,7 @@
     {{/* Comments JS. */}}
     {{ $comments_enabled := and site.DisqusShortname (not (or site.Params.disable_comments $.Params.disable_comments)) }}
     {{ if and $comments_enabled (site.Params.comment_count | default true) }}
-    <script id="dsq-count-scr" src="//{{ site.DisqusShortname }}.disqus.com/count.js" async></script>
+    <script id="dsq-count-scr" src="https://{{ site.DisqusShortname }}.disqus.com/count.js" async></script>
     {{ end }}
 
     {{/* Initialise code highlighting. */}}


### PR DESCRIPTION
### Explicit https scheme

There are cases where external script loading is currently [src="https: // ..."], and there are also places where it is [src="// ..."].

ex: https://github.com/gcushen/hugo-academic/blob/64cceae0995ff7ba3f362fa699f0e341b14bbca1/layouts/partials/site_head.html#L130

I think it is better to unify this.