### PR TITLE
Remove search-query id from 404 input.

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -7,7 +7,7 @@
   {{/* Show search box if Academic's search engine is enabled. */}}
   {{ if eq site.Params.search.engine 1 }}
   <form class="d-flex align-items-center mb-3">
-    <input name="q" type="search" class="form-control" id="search-query" placeholder="{{ i18n "search_placeholder" }}" autocomplete="off">
+    <input name="q" type="search" class="form-control" placeholder="{{ i18n "search_placeholder" }}" autocomplete="off">
   </form>
   {{ end }}
 

--- a/layouts/partials/docs_sidebar.html
+++ b/layouts/partials/docs_sidebar.html
@@ -12,7 +12,7 @@
   </button>
 
   {{ if eq site.Params.search.engine 1 }}
-  <input name="q" type="search" class="form-control" id="search-query" placeholder="{{ i18n "search_placeholder" }}" autocomplete="off">
+  <input name="q" type="search" class="form-control" placeholder="{{ i18n "search_placeholder" }}" autocomplete="off">
   {{ end }}
 </form>
 


### PR DESCRIPTION
Search query is propagated via the q parameter being added to the query
string when users hit enter.
The only reference to #search-query I found is for styling when dark
theme is enabled. The search widget on the page has the right background
color even when removing the id.

Fixes #1198 (HTML validation issues do the presence of duplicate ids on 404 page.)
