### PR TITLE
Allow custom edit_page_repo per folder

### DIFF
--- a/layouts/partials/edit_page.html
+++ b/layouts/partials/edit_page.html
@@ -1,7 +1,16 @@
-{{ if site.Params.edit_page.repo_url | and (index site.Params.edit_page.editable .Type) | and (ne .Params.editable false) | or .Params.editable }}
-<p class="edit-page">
-  <a href="{{site.Params.edit_page.repo_url}}/edit/{{site.Params.edit_page.repo_branch | default "master"}}/content/{{.File.Path}}">
-    <i class="fas fa-pen pr-2"></i>{{ i18n "edit_page" | default "Edit this page" }}
-  </a>
-</p>
+{{ if (or site.Params.edit_page .Params.edit_page) }}
+  {{ $edit_page :=  site.Params.edit_page }}
+  {{ $editable := index $edit_page.editable .Type  | and (ne .Params.editable false) | or .Params.editable}}
+  {{ if .Params.edit_page }}
+    {{ $edit_page =  .Params.edit_page }}
+    {{ $editable = ne .Params.editable false}}
+  {{ end }}
+
+  {{ if $edit_page.repo_url | and $editable }}
+  <p class="edit-page">
+    <a href="{{$edit_page.repo_url}}/edit/{{$edit_page.repo_branch | default "master"}}/content/{{.File.Path}}">
+      <i class="fas fa-pen pr-2"></i>{{ i18n "edit_page" | default "Edit this page" }}
+    </a>
+  </p>
+  {{ end }}
 {{ end }}

--- a/layouts/partials/edit_page.html
+++ b/layouts/partials/edit_page.html
@@ -1,14 +1,18 @@
 {{ if (or site.Params.edit_page .Params.edit_page) }}
   {{ $edit_page :=  site.Params.edit_page }}
   {{ $editable := index $edit_page.editable .Type  | and (ne .Params.editable false) | or .Params.editable}}
+  {{ $filepath := path.Join "content" .File.Path }}
   {{ if .Params.edit_page }}
     {{ $edit_page =  .Params.edit_page }}
     {{ $editable = ne .Params.editable false}}
-  {{ end }}
-
+    {{ if .Params.edit_page.submodule_dir }}
+      {{ $filepath = strings.TrimPrefix .Params.edit_page.submodule_dir $filepath }}
+    {{ end }}
+{{ end }}
+  
   {{ if $edit_page.repo_url | and $editable }}
   <p class="edit-page">
-    <a href="{{$edit_page.repo_url}}/edit/{{$edit_page.repo_branch | default "master"}}/content/{{.File.Path}}">
+    <a href="{{$edit_page.repo_url}}/edit/{{$edit_page.repo_branch | default "master"}}/{{$filepath}}">
       <i class="fas fa-pen pr-2"></i>{{ i18n "edit_page" | default "Edit this page" }}
     </a>
   </p>


### PR DESCRIPTION
### Purpose

`edit_page` option is great but is a general option and cannot be applied for multiple `docs` folder that are linked to different repo (which is my case).

### Documentation

This PR makes it possible to specify the `edit_page` parameter in the front matter of a file :
```toml
edit_page = {repo_url = "https://github.com/user/specific_repo", repo_branch = "master"}
editable = false #if this page should not be editable
```

How it works:
* Search for the `edit_page` variable in the config file...
* ...If `edit_page` is also defined in the front matter, then use this one
* ...Otherwise, continue as previously

### Tricks

`editable` is an option that appears in two different scopes:
* As an `array` and as a parameter of `edit_page` (*eg* `edit_page.editable={docs=true}}` in `Params.toml`
* As a `boolean` in the Front matter of a page to force the page to not be editable (*eg* `editable = false`)

This is somehow a "conflict". In this PR, as `edit_page` can be used in the front matter of a file, the `edit_page.editable` array will not be considered (inside the front matter). If the user wants this page not to be editable, the option must be set as previously as a boolean, otherwise whenever `edit_page` is defined in the front matter of a file, the page is assumed to be "editable" :

```toml
# in the front matter
edit_page = {..., editable = {docs = true}} # this "editable" is not considered at all
editable = false #unlike this one
```