### PR TITLE
Fix DOM structure of author page when no posts.

### DIFF
--- a/layouts/authors/list.html
+++ b/layouts/authors/list.html
@@ -33,8 +33,8 @@
         {{ end }}
       </ul>
     </div>
+    {{ end }}
   </div>
-  {{ end }}
 </section>
 
 {{- end -}}


### PR DESCRIPTION
### Purpose

Ensure the page DOM tree is well formed even when there are no posts to
list for a given author.