### PR TITLE
Add support for legal.md in footer

### DIFF
--- a/exampleSite/content/terms.md
+++ b/exampleSite/content/terms.md
@@ -1,0 +1,13 @@
+---
+title: Terms
+date: "2018-06-28T00:00:00+01:00"
+draft: true
+share: false
+
+# Optional header image (relative to `static/img/` folder).
+header:
+  caption: ""
+  image: ""
+---
+
+...

--- a/layouts/partials/site_footer.html
+++ b/layouts/partials/site_footer.html
@@ -1,13 +1,13 @@
 <footer class="site-footer">
-  {{ if (or (site.GetPage "legal.md") (site.GetPage "privacy.md")) }}
+  {{ if or (site.GetPage "terms.md") (site.GetPage "privacy.md") }}
   <p class="powered-by">
-    {{ with site.GetPage "legal.md" }}
-      {{ printf "<a href=\"%s\">%s</a>" .RelPermalink .Title | safeHTML }}
-    {{ end }}
     {{ with site.GetPage "privacy.md" }}
-      {{ if site.GetPage "legal.md" }} &middot; {{ end }}
       {{ printf "<a href=\"%s\">%s</a>" .RelPermalink .Title | safeHTML }}
     {{ end }}
+    {{ with site.GetPage "terms.md" }}
+      {{ if site.GetPage "privacy.md" }} &middot; {{ end }}
+      {{ printf "<a href=\"%s\">%s</a>" .RelPermalink .Title | safeHTML }}
+    {{ end }}    
   </p>
   {{ end }}
 

--- a/layouts/partials/site_footer.html
+++ b/layouts/partials/site_footer.html
@@ -1,7 +1,13 @@
 <footer class="site-footer">
-  {{ with site.GetPage "privacy.md" }}
+  {{ if (or (site.GetPage "legal.md") (site.GetPage "privacy.md")) }}
   <p class="powered-by">
-    {{ printf "<a href=\"%s\">%s</a>" .RelPermalink .Title | safeHTML }}
+    {{ with site.GetPage "legal.md" }}
+      {{ printf "<a href=\"%s\">%s</a>" .RelPermalink .Title | safeHTML }}
+    {{ end }}
+    {{ with site.GetPage "privacy.md" }}
+      {{ if site.GetPage "legal.md" }} &middot; {{ end }}
+      {{ printf "<a href=\"%s\">%s</a>" .RelPermalink .Title | safeHTML }}
+    {{ end }}
   </p>
   {{ end }}
 


### PR DESCRIPTION
### Purpose

To comply with regulations in the EU, it is wise to also add more precise legal information (aka "imprint") to a website. Regulation says that a link must be found on every page but as this is rather boring content, you don't want that in your menu. The footer has become a de facto standard to put such links.

The data privacy link is already there so it is only consequent to also add the same functionality for legal information.

This patch will help people to avoid customizing the `site_footer.html` file.