### PR TITLE
Allow comments for project, publication, and talk

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -159,7 +159,7 @@ sharing = true
   engine = 0
 
   # Which page types are commentable?
-  commentable = {page = true, post = true, docs = true}
+  commentable = {page = true, post = true, docs = true, project = true, publication = true, talk = true}
 
   # Configuration of Disqus.
   [comments.disqus]

--- a/layouts/project/single.html
+++ b/layouts/project/single.html
@@ -13,6 +13,8 @@
     {{ partial "tags.html" . }}
     {{ partial "page_author.html" . }}
 
+    {{ partial "comments" . }}
+
     {{ $page := . }}
     {{ $project := .File.ContentBaseName }}
 

--- a/layouts/publication/single.html
+++ b/layouts/publication/single.html
@@ -53,6 +53,8 @@
     {{ partial "tags.html" . }}
     {{ partial "page_author.html" . }}
 
+    {{ partial "comments" . }}
+
   </div>
 </div>
 

--- a/layouts/talk/single.html
+++ b/layouts/talk/single.html
@@ -66,6 +66,8 @@
     {{ partial "tags.html" . }}
     {{ partial "page_author.html" . }}
 
+    {{ partial "comments" . }}
+
   </div>
 </div>
 


### PR DESCRIPTION
This allows to selectively enable comments for projects, publications, and talks.