### PR TITLE
Add dedicated copyright parameter for HTML rendering

### DIFF
--- a/exampleSite/config/_default/config.toml
+++ b/exampleSite/config/_default/config.toml
@@ -11,8 +11,9 @@ title = "Academic"
 # End your URL with a `/` trailing slash, e.g. `https://example.com/`.
 baseurl = "/"
 
-# Enter a copyright notice to display in the site footer.
-# To display a copyright symbol, type `&copy;`. For current year, type `{year}`.
+# Enter a copyright notice.
+# This shall only be used for plain text information.
+# Use copyrightHTML in params.toml for HTML formatted information including dynamic year replacement.
 copyright = ""
 
 # Enable analytics by entering your Google Analytics tracking ID

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -11,6 +11,10 @@ day_night = true
 #   Choose from `default`, `classic`, `rose`, or `mr_robot`.
 font = "default"
 
+# Enter a copyright notice to display in the site footer.
+# To display a copyright symbol, type `&copy;`. For current year, type `{year}`.
+copyrightHTML = ""
+
 # Description for social sharing and search engines. If undefined, superuser role is used in place.
 description = ""
 

--- a/layouts/partials/site_footer.html
+++ b/layouts/partials/site_footer.html
@@ -12,7 +12,11 @@
   {{ end }}
 
   <p class="powered-by">
-    {{ with site.Copyright }}{{ replace . "{year}" now.Year | markdownify}} &middot; {{ end }}
+    {{ if .Site.Params.CopyrightHTML }}
+      {{ with .Site.Params.CopyrightHTML }}{{ replace . "{year}" now.Year | markdownify}} &middot; {{ end }}
+    {{ else }}
+      {{ with site.Copyright }}{{ replace . "{year}" now.Year | markdownify}} &middot; {{ end }}
+    {{ end }}
 
     Powered by the
     <a href="https://sourcethemes.com/academic/" target="_blank" rel="noopener">Academic theme</a> for


### PR DESCRIPTION
I think the global .Site.Copyright parameter is not intended to contain any HTML or variable text.
For example, it is used to generate RSS feeds (not just in rss.xml that Academic comes with) and such formatted text does not make sense there.

This patch introduces a separate parameter for HTML-formatted copyright notice that will be used instead. Backwards compatibility is ensured as the original behaviour is intouched unless someone would set the new parameter. 