### PR TITLE
Add missing webmanifest reference

### DIFF
--- a/layouts/partials/site_head.html
+++ b/layouts/partials/site_head.html
@@ -144,6 +144,7 @@
 
   <link rel="icon" type="image/png" href="{{ "/img/icon.png" | relURL }}">
   <link rel="apple-touch-icon" type="image/png" href="{{ "/img/icon-192.png" | relURL }}">
+  <link rel="manifest" href="{{ "index.webmanifest" | relURL }}">
 
   <link rel="canonical" href="{{ .Permalink }}">
 


### PR DESCRIPTION
I believe index.webmanifest shall be referenced from the HTML header section.