### PR TITLE
make icon path reference absolute in webmanifest

### DIFF
--- a/layouts/index.webmanifest
+++ b/layouts/index.webmanifest
@@ -5,14 +5,15 @@
   "theme_color": "{{ $scr.Get "primary" }}",
   "background_color": "{{ $scr.Get "primary" }}",
   "icons": [{
-    "src": "/img/icon-192.png",
+    "src": "{{site.BaseURL}}img/icon-192.png",
     "sizes": "192x192",
     "type": "image/png"
     }{{- if (fileExists "static/img/icon-512.png") -}}, {
-    "src": "/img/icon-512.png",
+    "src": "{{site.BaseURL}}img/icon-512.png",
     "sizes": "512x512",
     "type": "image/png"
      }{{end}}],
-  "display": "standalone",
-  "start_url": "./?utm_source=web_app_manifest"
+  "display": "standalone",{{if .IsTranslated}}
+  "start_url": "{{.Permalink}}?utm_source=web_app_manifest"{{else}}
+  "start_url": "./?utm_source=web_app_manifest"{{end}}
 }

--- a/layouts/index.webmanifest
+++ b/layouts/index.webmanifest
@@ -5,11 +5,11 @@
   "theme_color": "{{ $scr.Get "primary" }}",
   "background_color": "{{ $scr.Get "primary" }}",
   "icons": [{
-    "src": "img/icon-192.png",
+    "src": "/img/icon-192.png",
     "sizes": "192x192",
     "type": "image/png"
     }{{- if (fileExists "static/img/icon-512.png") -}}, {
-    "src": "img/icon-512.png",
+    "src": "/img/icon-512.png",
     "sizes": "512x512",
     "type": "image/png"
      }{{end}}],


### PR DESCRIPTION
I believe errors like this will be avoided by this patch:

````
Image https://staging--myurl.netlify.com/index.webmanifest?v=gAdNNvE9vr/img/icon-192.png is ill-formed
````

See https://realfavicongenerator.net/favicon_checker