### PR TITLE
Align portfolio toolbar with title text

### DIFF
--- a/layouts/partials/widgets/portfolio.html
+++ b/layouts/partials/widgets/portfolio.html
@@ -47,7 +47,7 @@
 
       {{/* Only show filter buttons if there are multiple filters. */}}
       {{ if gt (len $st.Params.content.filter_button) 1 }}
-      <div class="project-toolbar">
+      <div class="project-toolbar mt-2">
         <div class="project-filters">
           <div class="btn-toolbar">
             <div class="btn-group flex-wrap">


### PR DESCRIPTION
This will align the portfolio toolbar more accurately with the title text in the column left from it.