### PR TITLE
Specify rel='me' on outgoing social profile links.

### DIFF
--- a/layouts/partials/page_author.html
+++ b/layouts/partials/page_author.html
@@ -50,7 +50,7 @@
           {{ if not $scheme }}
             {{ $link = .link | relLangURL }}
           {{ else if in (slice "http" "https") $scheme }}
-            {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
+            {{ $target = "target=\"_blank\" rel=\"noopener me\"" }}
           {{ end }}
           <li>
             <a itemprop="sameAs" href="{{ $link | safeURL }}" {{ $target | safeHTMLAttr }}>

--- a/layouts/partials/widgets/about.html
+++ b/layouts/partials/widgets/about.html
@@ -56,7 +56,7 @@
         {{ if not $scheme }}
           {{ $link = .link | relLangURL }}
         {{ else if in (slice "http" "https") $scheme }}
-          {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
+          {{ $target = "target=\"_blank\" rel=\"noopener me\"" }}
         {{ end }}
         <li>
           <a itemprop="sameAs" href="{{ $link | safeURL }}" {{ $target | safeHTMLAttr }}>


### PR DESCRIPTION
This is functionally close to itemProp='sameAs', which is already on the
page but is not taken into account by some parties (e.g. Twitter).

https://developer.twitter.com/en/docs/twitter-for-websites/tweet-button/overview.html

(Note that twitter attribution via the `twitter:creator` field does not seem to work when `twitter:card` is set to `summary`)