### PR TITLE
Allow to exclude certain pages from RSS feed

### DIFF
--- a/exampleSite/content/privacy.md
+++ b/exampleSite/content/privacy.md
@@ -5,7 +5,7 @@ draft: true
 share: false
 commentable: false
 editable: false
-disablerss: true
+disablefeed: true
 
 # Optional header image (relative to `static/img/` folder).
 header:

--- a/exampleSite/content/privacy.md
+++ b/exampleSite/content/privacy.md
@@ -5,6 +5,7 @@ draft: true
 share: false
 commentable: false
 editable: false
+disablerss: true
 
 # Optional header image (relative to `static/img/` folder).
 header:

--- a/exampleSite/content/terms.md
+++ b/exampleSite/content/terms.md
@@ -5,7 +5,7 @@ draft: true
 share: false
 commentable: false
 editable: false
-disablerss: true
+disablefeed: true
 
 # Optional header image (relative to `static/img/` folder).
 header:

--- a/exampleSite/content/terms.md
+++ b/exampleSite/content/terms.md
@@ -5,6 +5,7 @@ draft: true
 share: false
 commentable: false
 editable: false
+disablerss: true
 
 # Optional header image (relative to `static/img/` folder).
 header:

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -25,7 +25,7 @@
       <link>{{ .Permalink }}</link>
     </image>
     {{end -}}
-    {{ range $pages }}
+    {{ range $pages }}{{ if not .Params.DisableRSS }}
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
@@ -33,6 +33,6 @@
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Content | html }}</description>
     </item>
-    {{ end }}
+    {{ end }}{{ end }}
   </channel>
 </rss>

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -25,7 +25,7 @@
       <link>{{ .Permalink }}</link>
     </image>
     {{end -}}
-    {{ range $pages }}{{ if not .Params.DisableRSS }}
+    {{ range $pages }}{{ if not .Params.DisableFeed }}
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>


### PR DESCRIPTION
This will allow to add `DisableFeed: true` to any content page to exclude it from the RSS feed.
For example, this is useful for `terms.md` or `privacy.md`.