### PR TITLE
fix link href to webmanifest for languages

### DIFF
--- a/layouts/partials/site_head.html
+++ b/layouts/partials/site_head.html
@@ -138,7 +138,7 @@
   <link rel="alternate" href="{{.RelPermalink}}" type="application/rss+xml" title="{{site.Title}}">
   {{ end }}
 
-  <link rel="manifest" href="{{ "index.webmanifest" | relURL }}">
+  <link rel="manifest" href="{{ "index.webmanifest" | relLangURL }}">
   <link rel="icon" type="image/png" href="{{ "img/icon-32.png" | relURL }}">
   <link rel="apple-touch-icon" type="image/png" href="{{ "img/icon-192.png" | relURL }}">
 

--- a/layouts/slides/baseof.html
+++ b/layouts/slides/baseof.html
@@ -9,7 +9,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="generator" content="Source Themes Academic {{ site.Data.academic.version }}">
 
-  <link rel="manifest" href="{{ "index.webmanifest" | relURL }}">
+  <link rel="manifest" href="{{ "index.webmanifest" | relLangURL }}">
   <link rel="icon" type="image/png" href="{{ "img/icon-32.png" | relURL }}">
   <link rel="apple-touch-icon" type="image/png" href="{{ "img/icon-192.png" | relURL }}">
 


### PR DESCRIPTION
Currently only the main language web manifest is linked for other languages.
This patch makes sure the localized webmanifest file is linked.