### PR TITLE
Summary on portfolio card marked as paragraph

### DIFF
--- a/layouts/partials/portfolio_li_card.html
+++ b/layouts/partials/portfolio_li_card.html
@@ -31,7 +31,7 @@
       <h4><a href="{{ $link }}" {{ $target | safeHTMLAttr }}>{{ $item.Title | markdownify | emojify }}</a></h4>
       {{ with $summary }}
       <div class="article-style">
-        {{ . | truncate 135 }}
+        <p>{{ . | truncate 135 }}</p>
       </div>
       {{ end }}
     </div>


### PR DESCRIPTION
### Purpose

The summary text on Project cards was showing up in disproportionately large font compared to card heading.

This updates `portfolio_li_card.html` partial and marks the summary as Paragraph.
