### PR TITLE
add option to disable authors and titles linking for publications

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -138,6 +138,12 @@ sharing = true
 
   # Citation style ("apa" or "mla")
   citation_style = "apa"
+  
+  # If true, publication's titles won't be linked to publication's pages
+  disable_links_title = false
+  
+  # If true, publication's authors won't be linked to their profile pages
+  disable_links_authors = false
 
 # Configuration of project pages.
 [projects]

--- a/layouts/partials/li_citation.html
+++ b/layouts/partials/li_citation.html
@@ -8,7 +8,11 @@
     {{ partial "page_metadata_authors" . }}
   </span>
   ({{- .Date.Format "2006" -}}).
-  <a href="{{ .RelPermalink }}" itemprop="name">{{ .Title }}</a>.
+  {{ if site.Params.publications.disable_links_title }} <!-- Unlink publication's title if disable_links_title is true -->
+    <a itemprop="name">{{ .Title }}</a>.
+  {{ else }}
+    <a href="{{ .RelPermalink }}" itemprop="name">{{ .Title }}</a>.
+  {{ end }}
   {{ if .Params.publication_short }}
   {{- .Params.publication_short | markdownify -}}.
   {{ else if .Params.publication }}
@@ -22,7 +26,11 @@
   <span itemprop="author" class="article-metadata li-cite-author">
     {{ partial "page_metadata_authors" . }}
   </span>.
-  <a href="{{ .RelPermalink }}" itemprop="name">{{ .Title }}</a>.
+  {{ if site.Params.publications.disable_links_title }} <!-- Unlink publication's title if disable_links_title is true -->
+    <a itemprop="name">{{ .Title }}</a>.
+  {{ else }}
+    <a href="{{ .RelPermalink }}" itemprop="name">{{ .Title }}</a>.
+  {{ end }}
   {{ if .Params.publication_short }}
   {{- .Params.publication_short | markdownify -}},
   {{ else if .Params.publication }}

--- a/layouts/partials/page_metadata_authors.html
+++ b/layouts/partials/page_metadata_authors.html
@@ -8,7 +8,7 @@
     {{- if gt $index 0 }}, {{ end -}}
     <span itemprop="author name" itemtype="http://schema.org/Person">
       {{- with $profile_page -}}
-        { if site.Params.publications.disable_links_authors }} <!-- Unlink publication's authors if disable_links_authors is true -->
+        {{ if site.Params.publications.disable_links_authors }} <!-- Unlink publication's authors if disable_links_authors is true -->
           <a>{{$name}}</a>
         {{- else -}}
           <a href="{{.RelPermalink}}">{{$name}}</a>

--- a/layouts/partials/page_metadata_authors.html
+++ b/layouts/partials/page_metadata_authors.html
@@ -8,7 +8,11 @@
     {{- if gt $index 0 }}, {{ end -}}
     <span itemprop="author name" itemtype="http://schema.org/Person">
       {{- with $profile_page -}}
-        <a href="{{.RelPermalink}}">{{$name}}</a>
+        { if site.Params.publications.disable_links_authors }} <!-- Unlink publication's authors if disable_links_authors is true -->
+          <a>{{$name}}</a>
+        {{- else -}}
+          <a href="{{.RelPermalink}}">{{$name}}</a>
+        {{- end -}}
       {{- else -}}
         {{$name}}
       {{- end -}}


### PR DESCRIPTION
### Purpose

Fixes #982 

As discussed in #982 this pull request allows to disable linking of authors' names and titles in publication page. 

It creates two optional parameters in `params.toml` in the `[publications]` section. Thus their is no breaking change.

```toml
[publications]
  date_format = "January 2006"
  citation_style = "apa"
  
  # If true, publication's titles won't be linked to publication's pages
  disable_links_title = true
  
  # If true, publication's authors won't be linked to their profile pages
  disable_links_authors = true
```

I hope I haven't made error in the pull request. Please tell me if I should make changes. I would be happy to know what you think about it.

### Code choice

Using a variable like `disable_links_title` don't create any breaking change. 
If we want to disable links be default it is possible to use an option like`links_title`.

Do you think an other name for the option would be better?

### Documentation

We could add informations about these two option in the documentation, perhaps in [Customization](https://sourcethemes.com/academic/docs/customization/)
