### PR TITLE
Fix: flip_alt_rows and Portfolio range 

### DIFF
--- a/layouts/partials/widgets/portfolio.html
+++ b/layouts/partials/widgets/portfolio.html
@@ -67,7 +67,11 @@
     {{ end }}
 
     <div class="{{ if or $st.Params.content.filter_button (eq $st.Params.design.view 3) }}isotope projects-container{{end}} {{if eq $st.Params.design.view 3}}js-layout-masonry{{else}}row js-layout-row{{end}} {{ if eq $st.Params.design.view 5 }}project-showcase mt-5{{end}}">
-      {{ range $idx, $item := where site.RegularPages "Type" $items_type }}
+      {{ $query := where site.RegularPages "Type" $items_type }}
+      {{ if $st.Params.folder }}
+        {{ $query = $query | intersect (where site.RegularPages "Section" $st.Params.folder )}}
+      {{end}}
+      {{ range $idx, $item := $query }}
 
         {{ $link := $item.RelPermalink }}
         {{ $target := "" }}


### PR DESCRIPTION
### PortFolio and "Folder" option

Portfolio widget displays `Pages` of a certain `Type` (say "Project") and (optionnaly) of a specific `folder`. In addition, the `flip_alt_rows` option makes the pages be shown with alternate rows. Deciding whether a project's image is located on the right or the left is based on the "index" of the project of the `range(...)` function.

This index might however be wrong: loop is currently done on every Pages of same `Type` whatever its folder. This can lead to a bad index due to "ghost" Pages, that exists in the html codes (but not displayed in the website!).

This problem obviously only appears if `project` widget is used more than once for different folders.

### Proposed Solution

Filter the range of Pages by intersecting their `Section` with the `folder` option (if set). In addition, this leads to a lighter html file (no ghost project).