### PR TITLE
fix font_theme for 1950s and coffee

### DIFF
--- a/data/themes/1950s.toml
+++ b/data/themes/1950s.toml
@@ -18,4 +18,4 @@ background = "#EAE7D6"
 home_section_odd = "#EAE7D6"
 home_section_even = "#EAE7D6"
 
-font = "rose"
+font_theme = "rose"

--- a/data/themes/coffee.toml
+++ b/data/themes/coffee.toml
@@ -18,4 +18,4 @@ background = "hsla(16, 24%, 85%, 1)"
 home_section_odd = "hsla(16, 24%, 85%, 1)"
 home_section_even = "hsla(16, 24%, 80%, 1)"
 
-font = "rose"
+font_theme = "rose"


### PR DESCRIPTION
This will fix using themes 1950s and coffee to avoid error

`````
The `<theme>` font set was not found! Check that the `font` option in `config/_default/params.toml` matches the name of an installed font set.
`````
