### PR TITLE
Removes a white space after the last author

### DIFF
--- a/layouts/partials/page_metadata_authors.html
+++ b/layouts/partials/page_metadata_authors.html
@@ -8,8 +8,12 @@
     {{- $name := $profile_page.Params.name | default ($value|markdownify) -}}
     {{- if gt $index 0 }}, {{ end -}}
     <span>
-      {{- with $profile_page -}}
-        {{ if $link_authors }}<a href="{{.RelPermalink}}">{{$name}}</a>{{else}}{{$name}}{{end}}
+      {{- if site.Params.link_authors -}}
+        {{- with $profile_page -}}
+          <a href="{{.RelPermalink}}">{{$name}}</a>
+        {{- else -}}
+          {{$name}}
+        {{- end -}}
       {{- else -}}
         {{$name}}
       {{- end -}}


### PR DESCRIPTION
Removes a white space after the last author if link_authors equal to false.

### Purpose
If link_authors param is equal to false, there is a space added between the last author and the dot. This PR removes this whitespace.

### Screenshots
![Current](https://user-images.githubusercontent.com/1058934/65557112-c522cc00-df3a-11e9-9e4a-41fd3aaf8582.png)
![With PR](https://user-images.githubusercontent.com/1058934/65557166-f3081080-df3a-11e9-8498-4a03258c452d.png)



