### PR TITLE
Fix People widget (+ add option)

### DIFF
--- a/exampleSite/content/home/people.md
+++ b/exampleSite/content/home/people.md
@@ -26,9 +26,6 @@ subtitle = ""
 
   # Show user's interests? (true/false)
   show_interests = true
-  
-  # Show user's organizations? (true/false)
-  show_organizations = false
 
 [design.background]
   # Apply a background color, gradient, or image.

--- a/exampleSite/content/home/people.md
+++ b/exampleSite/content/home/people.md
@@ -27,6 +27,9 @@ subtitle = ""
   # Show user's interests? (true/false)
   show_interests = true
   
+  # Show user's organizations? (true/false)
+  show_organizations = false
+
 [design.background]
   # Apply a background color, gradient, or image.
   #   Uncomment (by removing `#`) an option to apply it.

--- a/layouts/partials/widgets/people.html
+++ b/layouts/partials/widgets/people.html
@@ -25,7 +25,7 @@
     <h2 class="mb-4">{{ . | markdownify }}</h2>
   </div>
 
-  {{ $query := where (where site.Pages "Section" "authors") ".Params.content.user_groups" "intersect" (slice .) }}
+  {{ $query := where (where site.Pages "Section" "authors") ".Params.user_groups" "intersect" (slice .) }}
   {{ range $query }}
 
   {{ $avatar := (.Resources.ByType "image").GetMatch "*avatar*" }}
@@ -50,10 +50,9 @@
       <h2>{{with $link}}<a href="{{.}}">{{end}}{{ .Params.name }}{{if $link}}</a>{{end}}</h2>
       {{ with .Params.role }}<h3>{{ . | markdownify | emojify }}</h3>{{ end }}
       {{ if $show_social }}{{ partial "social_links" . }}{{ end }}
-      {{ if and $show_interests .Params.interests }}<p class="people-interests">{{ delimit . ", " | markdownify | emojify }}</p>{{ end }}
-      {{ end }}
+      {{ if and $show_interests .Params.interests }}<p class="people-interests">{{ delimit .Params.interests ", " | markdownify | emojify }}</p>{{ end }}
     </div>
   </div>
-
+  {{ end }}
   {{ end }}
 </div>

--- a/layouts/partials/widgets/people.html
+++ b/layouts/partials/widgets/people.html
@@ -22,13 +22,15 @@
   {{ end }}
 
   {{ range $page.Params.content.user_groups }}
+  {{ $query := where (where site.Pages "Section" "authors") ".Params.user_groups" "intersect" (slice .) }}
+
+  {{if $query}}
   <div class="col-md-12">
     <h2 class="mb-4">{{ . | markdownify }}</h2>
   </div>
+  {{end}}
 
-  {{ $query := where (where site.Pages "Section" "authors") ".Params.user_groups" "intersect" (slice .) }}
   {{ range $query }}
-
   {{ $avatar := (.Resources.ByType "image").GetMatch "*avatar*" }}
   {{/* Get link to user's profile page. */}}
   {{ $link := "" }}

--- a/layouts/partials/widgets/people.html
+++ b/layouts/partials/widgets/people.html
@@ -5,6 +5,7 @@
 {{ $page := .page }}
 {{ $show_social := $page.Params.design.show_social | default false }}
 {{ $show_interests := $page.Params.design.show_interests | default true }}
+{{ $show_organizations := $page.Params.design.show_organizations | default false }}
 
 <div class="row justify-content-center people-widget">
   {{ with $page.Title }}
@@ -49,6 +50,14 @@
     <div class="portrait-title">
       <h2>{{with $link}}<a href="{{.}}">{{end}}{{ .Params.name }}{{if $link}}</a>{{end}}</h2>
       {{ with .Params.role }}<h3>{{ . | markdownify | emojify }}</h3>{{ end }}
+      {{ if and $show_organizations .Params.organizations}}
+        {{ range .Params.organizations }}
+        <h3>{{ with .url }}<a href="{{ . }}" target="_blank"  itemprop="url" rel="noopener">{{ end }}
+          <span itemprop="name">{{ .name }}</span>
+          {{ if .url }}</a>{{ end }}
+        </h3>
+        {{ end }}
+      {{ end }}
       {{ if $show_social }}{{ partial "social_links" . }}{{ end }}
       {{ if and $show_interests .Params.interests }}<p class="people-interests">{{ delimit .Params.interests ", " | markdownify | emojify }}</p>{{ end }}
     </div>

--- a/layouts/partials/widgets/people.html
+++ b/layouts/partials/widgets/people.html
@@ -5,7 +5,6 @@
 {{ $page := .page }}
 {{ $show_social := $page.Params.design.show_social | default false }}
 {{ $show_interests := $page.Params.design.show_interests | default true }}
-{{ $show_organizations := $page.Params.design.show_organizations | default false }}
 
 <div class="row justify-content-center people-widget">
   {{ with $page.Title }}
@@ -52,14 +51,6 @@
     <div class="portrait-title">
       <h2>{{with $link}}<a href="{{.}}">{{end}}{{ .Params.name }}{{if $link}}</a>{{end}}</h2>
       {{ with .Params.role }}<h3>{{ . | markdownify | emojify }}</h3>{{ end }}
-      {{ if and $show_organizations .Params.organizations}}
-        {{ range .Params.organizations }}
-        <h3>{{ with .url }}<a href="{{ . }}" target="_blank"  itemprop="url" rel="noopener">{{ end }}
-          <span itemprop="name">{{ .name }}</span>
-          {{ if .url }}</a>{{ end }}
-        </h3>
-        {{ end }}
-      {{ end }}
       {{ if $show_social }}{{ partial "social_links" . }}{{ end }}
       {{ if and $show_interests .Params.interests }}<p class="people-interests">{{ delimit .Params.interests ", " | markdownify | emojify }}</p>{{ end }}
     </div>


### PR DESCRIPTION
### Purpose

People widget could be not working as pointed out in #1360.

This PR fixes multiple bugs :
- People widget was always empty. This is due to a wrong query, looking for `.Params.content.user_groups` for every `authors`. However, the `user_groups` belongs to `content` only for the people widget, not for the authors.
- Fix bug in displaying people interest: if frontmatter was written in toml, it did not work, in yaml it lead to an error (wrong context argument `.` instead of `.Params.interests`)
- Bad `</div>` placement in the `range` loop. This problem appears when multiple `user_groups` are set

This PR also proposes some enhancements:

- Hide `user_groups` if empty (no authors)
- Add an option to display people's organizations (or not (default)). 
