### PR TITLE
Talk page: do not display 'event' if empty

### DIFF
--- a/layouts/talk/single.html
+++ b/layouts/talk/single.html
@@ -27,6 +27,7 @@
     </div>
     <div class="d-md-none space-below"></div>
 
+    {{ if .Params.event }}
     <div class="row">
       <div class="col-md-1"></div>
       <div class="col-md-10">
@@ -37,11 +38,12 @@
             {{ .Params.event | markdownify }}
             {{ if .Params.event_url }}</a>{{ end }}
           </div>
-        </div>
+        </div> 
       </div>
       <div class="col-md-1"></div>
     </div>
     <div class="d-md-none space-below"></div>
+    {{ end }}
 
     {{ if .Params.location }}
     <div class="row">


### PR DESCRIPTION
### Purpose

Talk page always display "Event : " even if this field is empty. This happens, for example, if the website hosts the event of the talks.

### Screenshots

Example (in french):

![Screenshot-20191017110923-486x81](https://user-images.githubusercontent.com/5602767/66995066-aabdb780-f0ce-11e9-9964-353d47666835.png)


### Documentation

This fix simply add an `if` statement in the talk page (file `layouts/talk/single.html`).