### PR TITLE
Limit authors listed in metadata for publications

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -180,6 +180,9 @@ plugins_js  = []
 
   # Citation style ("apa" or "mla")
   citation_style = "apa"
+  
+  # Limit authors listed for publications
+  authors_max = 10
 
 # Configuration of project pages.
 [projects]

--- a/layouts/partials/page_metadata_authors.html
+++ b/layouts/partials/page_metadata_authors.html
@@ -2,11 +2,22 @@
 
 {{ $taxonomy := "authors" }}
 {{ with .Param $taxonomy }}
+  {{ $authors_max := index (sort (slice (site.Params.publications.authors_max | default (len .)) (len .))) 0 }}
+  {{ $limit_authors := gt (len .) $authors_max }}
+  {{ $authors_limited := . }}
+  {{ if $limit_authors }}
+    {{ if gt $authors_max 1 }}
+      {{ $authors_limited = union (first (sub $authors_max 1) .) (last 1 .) }}
+    {{ else }}
+      {{ $authors_limited = first $authors_max . }}
+    {{ end }}
+  {{ end }}
   {{ $link_authors := site.Params.link_authors | default true }}
-  {{ range $index, $value := . }}
+  {{ range $index, $value := $authors_limited }}
     {{- $profile_page := site.GetPage (printf "/%s/%s" $taxonomy (. | urlize)) -}}
     {{- $name := $profile_page.Params.name | default ($value|markdownify) -}}
     {{- if gt $index 0 }}, {{ end -}}
+    {{- if and $limit_authors (eq $index (sub $authors_max 1)) }} ..., {{ end -}}
     <span>
       {{- if and $profile_page $link_authors -}}
         <a href="{{$profile_page.RelPermalink}}">{{$name}}</a>


### PR DESCRIPTION
### Purpose

For publications with an unusual number of authors, the author list displayed for publications metadata takes up too much space. This patch proposes as new, optional parameter "authors_max" which can be used to limit the number of authors shown by full name. A subset of the authors (keeping the last author) is thus replaced by " ..., ". 

Before:

<img width="1680" alt="before" src="https://user-images.githubusercontent.com/9335112/68998266-42552800-087e-11ea-885b-48446abf4dea.png">

After:

<img width="1680" alt="after" src="https://user-images.githubusercontent.com/9335112/68998269-48e39f80-087e-11ea-999f-1976dcb22b27.png">

