### PR TITLE
Typo mistake "layout" instead of "layouts" for partials folder.

### DIFF
--- a/layouts/partials/custom_head.html
+++ b/layouts/partials/custom_head.html
@@ -1,4 +1,4 @@
 {{/* Do not directly modify this file! */}}
-{{/* Instead, create a `layout/partials/custom_head.html` file in your site and add your code to it. */}}
+{{/* Instead, create a `layouts/partials/custom_head.html` file in your site and add your code to it. */}}
 
-{{/* This partial is included in `themes/academic/layout/partials/site_head.html`. */}}
+{{/* This partial is included in `themes/academic/layouts/partials/site_head.html`. */}}

--- a/layouts/partials/custom_js.html
+++ b/layouts/partials/custom_js.html
@@ -1,4 +1,4 @@
 {{/* Do not directly modify this file! */}}
-{{/* Instead, create a `layout/partials/custom_js.html` file in your site and add your code to it. */}}
+{{/* Instead, create a `layouts/partials/custom_js.html` file in your site and add your code to it. */}}
 
-{{/* This partial is included in `themes/academic/layout/partials/site_js.html`. */}}
+{{/* This partial is included in `themes/academic/layouts/partials/site_js.html`. */}}


### PR DESCRIPTION
The instructions in the partials file direct users to create a folder "layout" instead of "layouts". It misleads new users who are unfamiliar with the project.