### PR TITLE
support word count

### DIFF
--- a/i18n/zh.yaml
+++ b/i18n/zh.yaml
@@ -32,6 +32,9 @@
 - id: edit_page
   translation: 编辑本页
 
+- id: word_count
+  translation: 字
+
 # Buttons
 
 - id: btn_preprint

--- a/layouts/partials/page_metadata.html
+++ b/layouts/partials/page_metadata.html
@@ -45,6 +45,13 @@
   </span>
   {{ end }}
 
+  {{ if and (eq $page.Type "post") (not (or (eq site.Params.word_count false) (eq $page.Params.word_count false))) }}
+  <span class="middot-divider"></span>
+  <span class="article-word-count">
+    {{ $page.WordCount }} {{ i18n "word_count" }} 
+  </span>
+  {{ end }}
+
   {{/* Show Disqus comment count if enabled. */}}
   {{ $disqus_enabled := eq site.Params.comments.engine 1 | and (index site.Params.comments.commentable $page.Type) | and (ne $page.Params.commentable false) | or $page.Params.commentable }}
   {{ if and $disqus_enabled (site.Params.comments.disqus.show_count | default true) }}


### PR DESCRIPTION
### Purpose
Just like `reading_time`, I add `word_count` to support word count of the content.

### Screenshots
Before
![image](https://user-images.githubusercontent.com/1380777/69125293-76c81e80-0ae0-11ea-8cf0-5f4be913e5a1.png)
After
![image](https://user-images.githubusercontent.com/1380777/69125310-7fb8f000-0ae0-11ea-9393-1dbc79512cb1.png)
### Documentation

Add `word_count = true` to `params.toml`
