### PR TITLE
Add option to use self hosted commento instance

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -212,6 +212,13 @@ plugins_js  = []
     shortname = ""  # Paste the shortname from your Disqus dashboard.
     show_count = true  # Show comment count in page header? (true/false)
 
+  # Configuration of Commento
+  [comments.commento]
+    # Set this url if you want to use a self hosted instance of commento.
+    # Otherwise leave empty.
+    # E.g. "https://commento.example.com"
+    url = ""
+
 ############################
 ## Search
 ############################

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -212,11 +212,9 @@ plugins_js  = []
     shortname = ""  # Paste the shortname from your Disqus dashboard.
     show_count = true  # Show comment count in page header? (true/false)
 
-  # Configuration of Commento
+  # Configuration of Commento.
   [comments.commento]
-    # Set this url if you want to use a self hosted instance of commento.
-    # Otherwise leave empty.
-    # E.g. "https://commento.example.com"
+    # If self-hosting Commento, enter its URL here (e.g. "https://commento.?.com"), otherwise leave empty.
     url = ""
 
 ############################

--- a/layouts/partials/comments/commento.html
+++ b/layouts/partials/comments/commento.html
@@ -1,2 +1,3 @@
 <div id="commento"></div>
-<script src="https://cdn.commento.io/js/commento.js" defer></script>
+{{ $url := (printf "%s/js/commento.js" (site.Params.comments.commento.url | default "https://cdn.commento.io")) }}
+<script src="{{$url}}" defer></script>


### PR DESCRIPTION
### Purpose

This change allows users to specify a url instead of having to edit the commento.html when they want to use commento with a self hosted instance. Other users of course do not have to change anything.

### Documentation

You can view the PR for the documentation [here](https://github.com/sourcethemes/academic-www/pull/19)