### PR TITLE
layouts: fix undefined variable

### DIFF
--- a/layouts/partials/site_js.html
+++ b/layouts/partials/site_js.html
@@ -47,6 +47,8 @@
     {{/* Initialise code highlighting. */}}
     {{ if $.Scratch.Get "highlight_enabled" }}
     <script>const code_highlighting = true;</script>
+    {{ else }}
+    <script>const code_highlighting = false;</script>
     {{ end }}
 
     {{ if ne site.Params.search.engine 0 }}


### PR DESCRIPTION
If "hightlight" was not enabled, the following error appeared in the
console:

    Uncaught ReferenceError: code_highlighting is not defined