### PR TITLE
made portofolio column sizes consistent with other widgets

### DIFF
--- a/layouts/partials/widgets/portfolio.html
+++ b/layouts/partials/widgets/portfolio.html
@@ -10,13 +10,13 @@
 {{/* Standard dual-column layout. */}}
 
 <div class="row">
-  <div class="col-xs-12 col-md-4 section-heading">
+  <div class="col-12 col-lg-4 section-heading">
 
     {{ with $st.Title }}<h1>{{ . | markdownify | emojify }}</h1>{{ end }}
     {{ with $st.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
 
   </div>
-  <div class="col-xs-12 col-md-8">
+  <div class="col-12 col-lg-8">
 
 {{ else }}
 {{/* Single column layout. */}}


### PR DESCRIPTION
### Purpose

The portfolio column sizes do not match other 2-column mode widgets, leading to the left column heading looking a little funny.  Compare to the about, experience, or any other 2-column widget.
