### PR TITLE
#1469 Google Lighthouse - Links do not have a discernible name

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -118,13 +118,13 @@
     <ul class="nav-icons navbar-nav flex-row ml-auto d-flex pl-md-2">
       {{ if site.Params.search.engine }}
       <li class="nav-item">
-        <a class="nav-link js-search" href="#"><i class="fas fa-search" aria-hidden="true"></i></a>
+        <a class="nav-link js-search" href="#" aria-label="Search this site"><i class="fas fa-search" aria-hidden="true"></i></a>
       </li>
       {{ end }}
 
       {{ if site.Params.day_night }}
       <li class="nav-item">
-        <a class="nav-link js-dark-toggle" href="#"><i class="fas fa-moon" aria-hidden="true"></i></a>
+        <a class="nav-link js-dark-toggle" href="#" aria-label="Toggle dark theme"><i class="fas fa-moon" aria-hidden="true"></i></a>
       </li>
       {{ end }}
 


### PR DESCRIPTION
Fixes #1469 Google Lighthouse - Links do not have a discernible name