### PR TITLE
feat: add id to figures to make them linkable.

### DIFF
--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -13,7 +13,7 @@
 {{/* Get caption. Support legacy `title` option. */}}
 {{ $caption := .Get "title" | default (.Get "caption") | default "" }}
 
-<figure{{ with .Get "class" }} class="{{.}}"{{ end }} {{ with $caption }}id="{{ anchorize . }}"{{ end }}>
+<figure{{ with .Get "class" }} class="{{.}}"{{ end }} {{ with $caption }}id="figure-{{ anchorize . }}"{{ end }}>
 
 {{ if $lightbox }}
   <a data-fancybox="{{$group}}" href="{{$image_src}}" {{ with $caption }}data-caption="{{ .|markdownify|emojify }}"{{ end }}>

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -13,7 +13,7 @@
 {{/* Get caption. Support legacy `title` option. */}}
 {{ $caption := .Get "title" | default (.Get "caption") | default "" }}
 
-<figure{{ with .Get "class" }} class="{{.}}"{{ end }}>
+<figure{{ with .Get "class" }} class="{{.}}"{{ end }} {{ with $caption }}id="{{ anchorize . }}"{{ end }}>
 
 {{ if $lightbox }}
   <a data-fancybox="{{$group}}" href="{{$image_src}}" {{ with $caption }}data-caption="{{ .|markdownify|emojify }}"{{ end }}>


### PR DESCRIPTION
### Purpose

Figures used in a technical articles shall have an ID in order to be able to create an anchor link (like headings in native HUGO). See https://gohugo.io/content-management/cross-references/

For a figure:
```
{{< figure src="image.jpg" title="A caption" numbered="true" lightbox="true" >}}
```
you should be a able to do the following in markdown text:
```
This is some awesome text. For more please see [the awesome figure]({{< relref "#a-caption" >}}
```
### Documentation

https://github.com/sourcethemes/academic-www/pull/20