### PR TITLE
Added cookie consent to assets.toml so that an offline site is possible

### DIFF
--- a/data/assets.toml
+++ b/data/assets.toml
@@ -66,9 +66,9 @@
   url = "https://cdnjs.cloudflare.com/ajax/libs/lazysizes/%s/lazysizes.min.js"
   async = true
 [js.cookieconsent]
-  version = "3.0.3"
-  sri = "sha512-CO0d9N3ml6Ik8P3mGy6j1Wx5KWnWzynQbiRJaZhM32FP99KRnT7O+hNNGGnuVktxjeYFU5xn9Kfb7c132wnbKw=="
-  url = "https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.js"
+  version = "3.1.1"
+  sri = "sha256-5VhCqFam2Cn+yjw61zbBNrbHVJ6SRydPeKopYlngbiQ="
+  url = "https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/%s/cookieconsent.min.js"
 
 # CSS
 
@@ -101,6 +101,6 @@
   sri = ""  # No SRI as highlight style is determined at run time.
   url = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/%s/styles/%s.min.css"
 [css.cookieconsent]
-  version = "3.0.3"
-  sri = "sha512-z4PhNX7vuL3xVChQ1m2AB9Yg5AULVxXcg/SpIdNs6c5H0NE8XYXysP+DGNKHfuwvY7kxvUdBeoGlODJ6+SfaPg=="
-  url = "https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.css"
+  version = "3.1.1"
+  sri = "sha256-zQ0LblD/Af8vOppw18+2anxsuaz3pWYyVWi+bTvTH8Q="
+  url = "https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/%s/cookieconsent.min.css"

--- a/data/assets.toml
+++ b/data/assets.toml
@@ -65,6 +65,10 @@
   sri = "sha256-Md1qLToewPeKjfAHU1zyPwOutccPAm5tahnaw7Osw0A="
   url = "https://cdnjs.cloudflare.com/ajax/libs/lazysizes/%s/lazysizes.min.js"
   async = true
+[js.cookieconsent]
+  version = "3.0.3"
+  sri = "sha512-CO0d9N3ml6Ik8P3mGy6j1Wx5KWnWzynQbiRJaZhM32FP99KRnT7O+hNNGGnuVktxjeYFU5xn9Kfb7c132wnbKw=="
+  url = "https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.js"
 
 # CSS
 
@@ -96,3 +100,7 @@
   version = "9.15.10"
   sri = ""  # No SRI as highlight style is determined at run time.
   url = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/%s/styles/%s.min.css"
+[css.cookieconsent]
+  version = "3.0.3"
+  sri = "sha512-z4PhNX7vuL3xVChQ1m2AB9Yg5AULVxXcg/SpIdNs6c5H0NE8XYXysP+DGNKHfuwvY7kxvUdBeoGlODJ6+SfaPg=="
+  url = "https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.css"

--- a/layouts/partials/cookie_consent.html
+++ b/layouts/partials/cookie_consent.html
@@ -1,13 +1,12 @@
 {{ if site.Params.privacy_pack }}
-{{ $scr := .Scratch }}
-{{ $js := site.Data.assets.js }}
-{{ $css := site.Data.assets.css }}
-{{ if ($scr.Get "use_cdn") }}
-  {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\" title=\"cookieconsent\"></script>" (printf $js.cookieconsent.url $js.cookieconsent.version) $js.cookieconsent.sri | safeHTML }}
-  {{ printf "<link rel=\"stylesheet\" href=\"%s\" crossorigin=\"anonymous\" title=\"cookieconsent\">" (printf $css.cookieconsent.url $css.cookieconsent.version) | safeHTML }}
-{{ end }}
-
-<script>
+  {{ $scr := .Scratch }}
+  {{ $js := site.Data.assets.js }}
+  {{ $css := site.Data.assets.css }}
+  {{ if ($scr.Get "use_cdn") }}
+    {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" (printf $js.cookieconsent.url $js.cookieconsent.version) $js.cookieconsent.sri | safeHTML }}
+    {{ printf "<link rel=\"stylesheet\" href=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\">" (printf $css.cookieconsent.url $css.cookieconsent.version) $css.cookieconsent.sri | safeHTML }}
+  {{ end }}
+  <script>
   window.addEventListener("load", function(){
     window.cookieconsent.initialise({
       "palette": {
@@ -25,8 +24,8 @@
         "message": {{ i18n "cookie_message" | default "This website uses cookies to ensure you get the best experience on our website." }},
         "dismiss": {{ i18n "cookie_dismiss" | default "Got it!" }},
         "link": {{ i18n "cookie_learn" | default "Learn more" }},
-        "href": {{ with site.GetPage "privacy.md" }}{{ printf "%s" .RelPermalink }}{{ else }}"https://cookies.insites.com"{{ end }}
+        "href": {{ with site.GetPage "privacy.md" }}{{ printf "%s" .RelPermalink }}{{ else }}"https://www.cookiesandyou.com"{{ end }}
       }
     })});
-</script>
+  </script>
 {{ end }}

--- a/layouts/partials/cookie_consent.html
+++ b/layouts/partials/cookie_consent.html
@@ -1,7 +1,12 @@
 {{ if site.Params.privacy_pack }}
 {{ $scr := .Scratch }}
-<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.css">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.js"></script>
+{{ $js := site.Data.assets.js }}
+{{ $css := site.Data.assets.css }}
+{{ if ($scr.Get "use_cdn") }}
+  {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\" title=\"cookieconsent\"></script>" (printf $js.cookieconsent.url $js.cookieconsent.version) $js.cookieconsent.sri | safeHTML }}
+  {{ printf "<link rel=\"stylesheet\" href=\"%s\" crossorigin=\"anonymous\" title=\"cookieconsent\">" (printf $css.cookieconsent.url $css.cookieconsent.version) | safeHTML }}
+{{ end }}
+
 <script>
   window.addEventListener("load", function(){
     window.cookieconsent.initialise({


### PR DESCRIPTION
### Purpose

There was an css and js url listed directly in the code. This is not consistent to the other code, which uses assets.toml. Furthermore now it is easier possible to create an offline site with your admin tool. 