### PR TITLE
Fix tag cloud size calculation

### DIFF
--- a/layouts/partials/widgets/tag_cloud.html
+++ b/layouts/partials/widgets/tag_cloud.html
@@ -29,6 +29,7 @@
     {{ if ne $count 0 }}
 
       {{ $fontDelta := sub $fontBig $fontSmall }}
+      {{/* Warning: Hugo's `Reverse` function appears to operate in-place, hence the order of performing $max/$min matters. */}}
       {{ $max := add (len (index $tags 0).Pages) 1 }}
       {{ $min := len (index ($tags).Reverse 0).Pages }}
       {{ $delta := sub $max $min }}

--- a/layouts/partials/widgets/tag_cloud.html
+++ b/layouts/partials/widgets/tag_cloud.html
@@ -29,8 +29,8 @@
     {{ if ne $count 0 }}
 
       {{ $fontDelta := sub $fontBig $fontSmall }}
-      {{ $min := len (index ($tags).Reverse 0).Pages }}
       {{ $max := add (len (index $tags 0).Pages) 1 }}
+      {{ $min := len (index ($tags).Reverse 0).Pages }}
       {{ $delta := sub $max $min }}
       {{ $fontStep := div $fontDelta $delta }}
 


### PR DESCRIPTION
### Purpose

Calculate max value before min since $tags list is mutable to reverse function.

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/5092581/71432159-4e18f180-273c-11ea-96b8-b27d25806e6b.png)

After:
![image](https://user-images.githubusercontent.com/5092581/71432129-275abb00-273c-11ea-9d7d-b58b55192310.png)

