### PR TITLE
Exclude generated Hugo resources from git repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Hugo
 exampleSite/public/
+resources/_gen/
 
 # Jupyter
 .ipynb_checkpoints/


### PR DESCRIPTION
In eb953ed47581f9f35eb5e6cbca29901c67ff5ffd, exclusion of `resources/` got removed.
However, at least one subdirectory for locally generated content shall still be excluded from the repo.