### PR TITLE
feat: allow specifying of formspree form id

### DIFF
--- a/exampleSite/content/home/contact.md
+++ b/exampleSite/content/home/contact.md
@@ -16,5 +16,8 @@ autolink = true
 #   1: Netlify (requires that the site is hosted by Netlify)
 #   2: formspree.io
 email_form = 2
+
+# The id of your formspree form
+formspree_form_id = ""
 +++
 

--- a/layouts/partials/widgets/contact.html
+++ b/layouts/partials/widgets/contact.html
@@ -18,10 +18,16 @@
     {{ if eq $page.Params.email_form 1 }}
       {{ $post_action = "netlify" }}
     {{ else }}
-      {{ if not $data.email }}
-        {{ errorf "Please set an email address for the contact form using the `email` parameter in `params.toml`. Otherwise, set `email_form = 0` to disable the contact form." }}
+      {{ $form_id := "" }}
+      {{ if $page.Params.formspree_form_id }}
+        {{ $form_id = $page.Params.formspree_form_id}}
+      {{ else }}
+        {{ if not $data.email }}
+          {{ errorf "Please set an email address for the contact form using the `email` parameter in `params.toml`. Otherwise, set `email_form = 0` to disable the contact form." }}
+        {{ end }}
+        {{ $form_id = $data.email }}
       {{ end }}
-      {{ $post_action = printf "action=\"https://formspree.io/%s\"" $data.email }}
+      {{ $post_action = printf "action=\"https://formspree.io/%s\"" $form_id }}
     {{end}}
 
     <div class="mb-3">


### PR DESCRIPTION
### Purpose

Currently it is not possible to specify the form id when creating a form using the formspree web interface. With this change it is possible to specify the id while still falling back to using the mail address when no id is provided.

### Documentation

See https://github.com/sourcethemes/academic-www/pull/22
