### PR TITLE
fix: Use localstorage only if switchable

### DIFF
--- a/assets/js/academic.js
+++ b/assets/js/academic.js
@@ -423,7 +423,12 @@
       // Default to day (light) theme.
       defaultThemeVariation = 0;
     }
-    let dark_mode = parseInt(localStorage.getItem('dark_mode') || defaultThemeVariation);
+
+    let dark_mode = defaultThemeVariation;
+    // Use localstorage if dark variation is allowed by admin and the key exists.
+    if ($('.js-dark-toggle').length && localStorage.getItem("username") !== null) {
+      dark_mode = parseInt(localStorage.getItem('dark_mode'));
+    }
 
     // Is code highlighting enabled in site config?
     const codeHlEnabled = $('link[title=hl-light]').length > 0;


### PR DESCRIPTION
Use localstorage if dark variation is allowed by admin and the key exists.

### Purpose

If the admin **removes** the "dark variation", the default is still read from the localstorage and there is no easy way for an end-user to use the mode defined by the theme (As far as I know, the only way is to use the developer options of the browser and delete the key there). Additionally, reading a persistent state makes sense if you can change this state. Otherwise, I think that the default should be used.

### Screenshots

Not available.

### Documentation

No documentation change.
