### PR TITLE
Quote font-families

### DIFF
--- a/assets/scss/academic/_root.scss
+++ b/assets/scss/academic/_root.scss
@@ -3,7 +3,7 @@
  **************************************************/
 
 html {
-  font-family: $sta-font-body, sans-serif;
+  font-family: "#{$sta-font-body}", sans-serif;
   font-size: #{$sta-font-size-small}px;
   color: rgba(0,0,0,0.8);
   line-height: 1.65;
@@ -65,7 +65,7 @@ ul.task-list li input[type="checkbox"] {
 
 /* Navigation bar text */
 .navbar-light {
-  font-family: $sta-font-nav, sans-serif;
+  font-family: "#{$sta-font-nav}", sans-serif;
   font-weight: 400;
   line-height: 1.25;
   text-rendering: optimizeLegibility;
@@ -73,7 +73,7 @@ ul.task-list li input[type="checkbox"] {
 
 /* Headings */
 h1, h2, h3, h4, h5, h6 {
-  font-family: $sta-font-heading, sans-serif;
+  font-family: "#{$sta-font-heading}", sans-serif;
   font-weight: 400;
   margin-top: 1rem;
   margin-bottom: .5rem;
@@ -166,7 +166,7 @@ figcaption.numbered {
 
 pre,
 code {
-  font-family: $sta-font-mono, monospace;
+  font-family: "#{$sta-font-mono}", monospace;
   color: #c7254e;
   background-color: #f9f2f4;
 }

--- a/assets/scss/vendor/bootstrap/_buttons.scss
+++ b/assets/scss/vendor/bootstrap/_buttons.scss
@@ -6,7 +6,7 @@
 
 .btn {
   display: inline-block;
-  font-family: $btn-font-family;
+  font-family: "#{$btn-font-family}";
   font-weight: $btn-font-weight;
   color: $body-color;
   text-align: center;

--- a/assets/scss/vendor/bootstrap/_custom-forms.scss
+++ b/assets/scss/vendor/bootstrap/_custom-forms.scss
@@ -221,7 +221,7 @@
   width: 100%;
   height: $custom-select-height;
   padding: $custom-select-padding-y ($custom-select-padding-x + $custom-select-indicator-padding) $custom-select-padding-y $custom-select-padding-x;
-  font-family: $custom-select-font-family;
+  font-family: "#{$custom-select-font-family}";
   @include font-size($custom-select-font-size);
   font-weight: $custom-select-font-weight;
   line-height: $custom-select-line-height;
@@ -344,7 +344,7 @@
   z-index: 1;
   height: $custom-file-height;
   padding: $custom-file-padding-y $custom-file-padding-x;
-  font-family: $custom-file-font-family;
+  font-family: "#{$custom-file-font-family}";
   font-weight: $custom-file-font-weight;
   line-height: $custom-file-line-height;
   color: $custom-file-color;

--- a/assets/scss/vendor/bootstrap/_forms.scss
+++ b/assets/scss/vendor/bootstrap/_forms.scss
@@ -9,7 +9,7 @@
   width: 100%;
   height: $input-height;
   padding: $input-padding-y $input-padding-x;
-  font-family: $input-font-family;
+  font-family: "#{$input-font-family}";
   @include font-size($input-font-size);
   font-weight: $input-font-weight;
   line-height: $input-line-height;

--- a/assets/scss/vendor/bootstrap/_reboot.scss
+++ b/assets/scss/vendor/bootstrap/_reboot.scss
@@ -45,7 +45,7 @@ article, aside, figcaption, figure, footer, header, hgroup, main, nav, section {
 
 body {
   margin: 0; // 1
-  font-family: $font-family-base;
+  font-family: "#{$font-family-base}";
   @include font-size($font-size-base);
   font-weight: $font-weight-base;
   line-height: $line-height-base;
@@ -218,7 +218,7 @@ pre,
 code,
 kbd,
 samp {
-  font-family: $font-family-monospace;
+  font-family: "#{$font-family-monospace}";
   @include font-size(1em); // Correct the odd `em` font sizing in all browsers.
 }
 

--- a/assets/scss/vendor/bootstrap/_type.scss
+++ b/assets/scss/vendor/bootstrap/_type.scss
@@ -7,7 +7,7 @@
 h1, h2, h3, h4, h5, h6,
 .h1, .h2, .h3, .h4, .h5, .h6 {
   margin-bottom: $headings-margin-bottom;
-  font-family: $headings-font-family;
+  font-family: "#{$headings-font-family}";
   font-weight: $headings-font-weight;
   line-height: $headings-line-height;
   color: $headings-color;

--- a/assets/scss/vendor/bootstrap/mixins/_reset-text.scss
+++ b/assets/scss/vendor/bootstrap/mixins/_reset-text.scss
@@ -1,5 +1,5 @@
 @mixin reset-text() {
-  font-family: $font-family-base;
+  font-family: "#{$font-family-base}";
   // We deliberately do NOT reset font-size or word-wrap.
   font-style: normal;
   font-weight: $font-weight-normal;

--- a/assets/scss/vendor/bootstrap/utilities/_text.scss
+++ b/assets/scss/vendor/bootstrap/utilities/_text.scss
@@ -4,7 +4,7 @@
 // Text
 //
 
-.text-monospace { font-family: $font-family-monospace !important; }
+.text-monospace { font-family: "#{$font-family-monospace}" !important; }
 
 // Alignment
 


### PR DESCRIPTION
### Purpose

When trying to use certain font names (e.g., `Exo 2`), CSS requires them to be quoted. Note that at some point in the pipeline, even quotation explicitly added to the configuration file is stripped.

This PR changes the SCSS rules that define a `font-family` based on a variable to quote that variable.

### Documentation

No documentation change necessary, just makes a feature work as advertised.
