### PR TITLE
Look for all kinds of pages for pages widget

### DIFF
--- a/exampleSite/content/home/posts.md
+++ b/exampleSite/content/home/posts.md
@@ -23,6 +23,12 @@ subtitle = ""
   # Page order. Descending (desc) or ascending (asc) date.
   order = "desc"
 
+  # Set of pages:
+  # * "RegularPages" for content pages, i.e. ones with kind = "page"
+  # * "Pages" for all pages in current language
+  #   (including "page", "home", "section", "taxonomy", "taxonomyTerm")
+  pages_set = "RegularPages"
+
   # Filter posts by a taxonomy term.
   [content.filters]
     tag = ""

--- a/layouts/partials/widgets/pages.html
+++ b/layouts/partials/widgets/pages.html
@@ -14,7 +14,15 @@
 {{ $items_sort := $st.Params.content.order | default "desc" }}
 
 {{/* Query */}}
-{{ $query := where site.RegularPages "Type" $items_type }}
+{{ $pages_set_name := $st.Params.content.pages_set | default "RegularPages" }}
+{{ $pages_set_scratch := newScratch }}
+{{ if eq $pages_set_name "Pages" }}
+  {{ $pages_set_scratch.Set "pages_set" site.Pages }}
+{{ else if eq $pages_set_name "RegularPages" }}
+  {{ $pages_set_scratch.Set "pages_set" site.RegularPages }}
+{{ end }}
+{{ $query := where ($pages_set_scratch.Get "pages_set") "Type" $items_type }}
+
 {{ $archive_page := site.GetPage "Section" $items_type }}
 
 {{/* Filters */}}


### PR DESCRIPTION
When creating a multi-part blog post, I create a directory, an `_index.md` inside of it with a foreword or the first chapter, and .md files with chapters alongside the `_index.md`. However, even if I specify `type: post` in the front matter of `_index.md`, it's never picked up by the "pages" widget: its kind is not "page" but "section."

Kind of a page doesn't look like something that can be overridden in a front matter, so here's my best guess on how to get where I want to be: make "pages" widget look for the specified type not only among regular pages (pages of kind "page") but all the pages of the current language.

Not sure it's the right way to go, though, so if someone knows how to do it better, please drop a comment.