### PR TITLE
Improve Offline Site Support

### DIFF
--- a/data/assets.toml
+++ b/data/assets.toml
@@ -15,6 +15,7 @@
   version = "9.15.10"
   sri = "sha256-1zu+3BnLYV9LdiY85uXMzii3bdrkelyp37e0ZyTAQh0="
   url = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/%s/highlight.min.js"
+  language_url = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/%s/languages/%s.min.js"
 [js.mathJax]
   version = "3"
   sri = ""  # No SRI as dynamically generated.

--- a/data/assets.toml
+++ b/data/assets.toml
@@ -19,6 +19,7 @@
   version = "3"
   sri = ""  # No SRI as dynamically generated.
   url = "https://cdn.jsdelivr.net/npm/mathjax@%s/es5/tex-chtml.js"
+  download_url = "https://github.com/mathjax/MathJax/archive/master.zip"
   async = true
 [js.isotope]
   version = "3.0.6"
@@ -73,13 +74,15 @@
 # CSS
 
 [css.fontAwesome]
-  version = "5.12.0-1"
+  version = "5.12.1"
   sri = "sha256-4w9DunooKSr3MFXHXWyFER38WmPdm361bQS/2KUWZbU="
   url = "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/%s/css/all.min.css"
+  download_url = "https://github.com/FortAwesome/Font-Awesome/releases/download/%s/fontawesome-free-%s-web.zip"
 [css.academicons]
   version = "1.8.6"
   sri = "sha256-uFVgMKfistnJAfoCUQigIl+JfUaP47GrRKjf6CTPVmw="
   url = "https://cdnjs.cloudflare.com/ajax/libs/academicons/%s/css/academicons.min.css"
+  download_url = "https://github.com/jpswalsh/academicons/archive/v%s.zip"
 [css.leaflet]
   version = "1.5.1"
   sri = "sha256-SHMGCYmST46SoyGgo4YR/9AlK1vf3ff84Aq9yK4hdqM="

--- a/layouts/partials/site_head.html
+++ b/layouts/partials/site_head.html
@@ -59,6 +59,11 @@
   {{ if and (fileExists (printf "static/vendor/css/%s" ($scr.Get "vendor_css_filename"))) (fileExists (printf "static/vendor/js/%s" ($scr.Get "vendor_js_filename"))) }}
     {{ $scr.Set "use_cdn" 0 }}
     <link rel="stylesheet" href="{{ printf "/vendor/css/%s" ($scr.Get "vendor_css_filename") | relURL }}">
+
+    {{/* Only load MathJax if required. */}}
+    {{ if (or $.Params.math site.Params.math) }}
+      <script src="/vendor/js/mathJax/tex-chtml.js" async></script>
+    {{end}}
   {{ else }}
     {{ $scr.Set "use_cdn" 1 }}
     {{ printf "<link rel=\"stylesheet\" href=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\">" (printf $css.academicons.url $css.academicons.version) $css.academicons.sri | safeHTML }}

--- a/layouts/partials/site_head.html
+++ b/layouts/partials/site_head.html
@@ -56,9 +56,32 @@
   {{/* Attempt to load local vendor CSS, otherwise load from CDN. */}}
   {{ $scr.Set "vendor_css_filename" "main.min.css" }}
   {{ $scr.Set "vendor_js_filename" "main.min.js" }}
+  {{/* Default to enabling highlighting, but allow the user to override it in .Params or site.Params.
+        Use $scr to store "highlight_enabled", so that we can read it again in footer.html. */}}
+  {{ $scr.Set "highlight_enabled" true }}
+  {{ if isset .Params "highlight" }}
+    {{ $scr.Set "highlight_enabled" .Params.highlight }}
+  {{ else if isset site.Params "highlight" }}
+    {{ $scr.Set "highlight_enabled" site.Params.highlight }}
+  {{ end }}
   {{ if and (fileExists (printf "static/vendor/css/%s" ($scr.Get "vendor_css_filename"))) (fileExists (printf "static/vendor/js/%s" ($scr.Get "vendor_js_filename"))) }}
     {{ $scr.Set "use_cdn" 0 }}
     <link rel="stylesheet" href="{{ printf "/vendor/css/%s" ($scr.Get "vendor_css_filename") | relURL }}">
+
+    {{ if ($scr.Get "highlight_enabled") }}
+      {{ $v := $css.highlight.version }}
+      {{ with site.Params.highlight_style }}
+        {{/* Already done: asset is bundled into the main vendor css */}}
+      {{ else }}
+        {{ if eq ($scr.Get "light") true }}
+          <link rel="stylesheet" href="/vendor/css/github.css" title="hl-light">
+          <link rel="stylesheet" href="/vendor/css/dracula.css" title="hl-dark" disabled>
+        {{ else }}
+          <link rel="stylesheet" href="/vendor/css/github.css" title="hl-light" disabled>
+          <link rel="stylesheet" href="/vendor/css/dracula.css" title="hl-dark">
+        {{ end }}
+      {{ end }}
+    {{ end }}
 
     {{/* Only load MathJax if required. */}}
     {{ if (or $.Params.math site.Params.math) }}
@@ -70,14 +93,6 @@
     {{ printf "<link rel=\"stylesheet\" href=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\">" (printf $css.fontAwesome.url $css.fontAwesome.version) $css.fontAwesome.sri | safeHTML }}
     {{ printf "<link rel=\"stylesheet\" href=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\">" (printf $css.fancybox.url $css.fancybox.version) $css.fancybox.sri | safeHTML }}
 
-    {{/* Default to enabling highlighting, but allow the user to override it in .Params or site.Params.
-         Use $scr to store "highlight_enabled", so that we can read it again in footer.html. */}}
-    {{ $scr.Set "highlight_enabled" true }}
-    {{ if isset .Params "highlight" }}
-      {{ $scr.Set "highlight_enabled" .Params.highlight }}
-    {{ else if isset site.Params "highlight" }}
-      {{ $scr.Set "highlight_enabled" site.Params.highlight }}
-    {{ end }}
     {{ if ($scr.Get "highlight_enabled") }}
       {{ $v := $css.highlight.version }}
       {{ with site.Params.highlight_style }}

--- a/layouts/partials/site_head.html
+++ b/layouts/partials/site_head.html
@@ -56,9 +56,9 @@
   {{/* Attempt to load local vendor CSS, otherwise load from CDN. */}}
   {{ $scr.Set "vendor_css_filename" "main.min.css" }}
   {{ $scr.Set "vendor_js_filename" "main.min.js" }}
-  {{ if and (fileExists (printf "static/css/vendor/%s" ($scr.Get "vendor_css_filename"))) (fileExists (printf "static/js/vendor/%s" ($scr.Get "vendor_js_filename"))) }}
+  {{ if and (fileExists (printf "static/vendor/css/%s" ($scr.Get "vendor_css_filename"))) (fileExists (printf "static/vendor/js/%s" ($scr.Get "vendor_js_filename"))) }}
     {{ $scr.Set "use_cdn" 0 }}
-    <link rel="stylesheet" href="{{ printf "/css/vendor/%s" ($scr.Get "vendor_css_filename") | relURL }}">
+    <link rel="stylesheet" href="{{ printf "/vendor/css/%s" ($scr.Get "vendor_css_filename") | relURL }}">
   {{ else }}
     {{ $scr.Set "use_cdn" 1 }}
     {{ printf "<link rel=\"stylesheet\" href=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\">" (printf $css.academicons.url $css.academicons.version) $css.academicons.sri | safeHTML }}

--- a/layouts/partials/site_js.html
+++ b/layouts/partials/site_js.html
@@ -3,7 +3,7 @@
     {{/* Attempt to load local vendor JS, otherwise load from CDN. */}}
     {{ $js := site.Data.assets.js }}
     {{ if not ($scr.Get "use_cdn") }}
-      <script src="{{ printf "/js/vendor/%s" ($scr.Get "vendor_js_filename") | relURL }}"></script>
+      <script src="{{ printf "/vendor/js/%s" ($scr.Get "vendor_js_filename") | relURL }}"></script>
     {{ else }}
       {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" (printf $js.jQuery.url $js.jQuery.version) $js.jQuery.sri | safeHTML }}
       {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" (printf $js.imagesLoaded.url $js.imagesLoaded.version) $js.imagesLoaded.sri | safeHTML }}

--- a/layouts/partials/site_js.html
+++ b/layouts/partials/site_js.html
@@ -4,6 +4,10 @@
     {{ $js := site.Data.assets.js }}
     {{ if not ($scr.Get "use_cdn") }}
       <script src="{{ printf "/vendor/js/%s" ($scr.Get "vendor_js_filename") | relURL }}"></script>
+
+      {{ if or .Params.diagram site.Params.diagram }}
+        <script title="mermaid">/* used by academic.js */</script>
+      {{ end }}
     {{ else }}
       {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" (printf $js.jQuery.url $js.jQuery.version) $js.jQuery.sri | safeHTML }}
       {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" (printf $js.imagesLoaded.url $js.imagesLoaded.version) $js.imagesLoaded.sri | safeHTML }}

--- a/layouts/partials/site_js.html
+++ b/layouts/partials/site_js.html
@@ -68,7 +68,11 @@
 
     {{/* Load hash anchors for documentation pages. */}}
     {{ if eq .Type "docs" }}
-    {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" (printf $js.anchor.url $js.anchor.version) $js.anchor.sri | safeHTML }}
+    {{ if fileExists (printf "static/vendor/js/%s" ($scr.Get "vendor_js_filename")) }}
+      {{/* vendored JS is already loaded */}}
+    {{ else }}
+      {{ printf "<script src=\"%s\" integrity=\"%s\" crossorigin=\"anonymous\"></script>" (printf $js.anchor.url $js.anchor.version) $js.anchor.sri | safeHTML }}
+    {{ end }}
     <script>
       anchors.add();
     </script>


### PR DESCRIPTION
### Purpose

This PR supports [academic admin PR 57](https://github.com/sourcethemes/academic-admin/pull/57) in improving offline support and consolidating the vendor directories.

Makes advances on #1167.

Also adds logic to not request anchor.js when its vendored copy is available.

### Documentation

It might be helpful to note in the changelog that the vendor directories have been consolidated as `static/vendor`.
