### PR TITLE
Adding link from featured to archive page of all publications

### DIFF
--- a/exampleSite/content/home/featured.md
+++ b/exampleSite/content/home/featured.md
@@ -11,9 +11,6 @@ weight = 80  # Order that this section will appear.
 title = "Featured Publications"
 subtitle = ""
 
-# To include a "See all" link which links to all publications etc set `link_to_more` to "true" (uncomment the below)
-# link_to_more = true
-
 [content]
   # Page type to display. E.g. post, talk, or publication.
   page_type = "publication"
@@ -23,6 +20,9 @@ subtitle = ""
 
   # Page order. Descending (desc) or ascending (asc) date.
   order = "desc"
+
+  # Show a "See all pages" link underneath the featured content?
+  link_to_archive = false
 
   # Filter posts by a taxonomy term.
   [content.filters]

--- a/exampleSite/content/home/featured.md
+++ b/exampleSite/content/home/featured.md
@@ -11,6 +11,9 @@ weight = 80  # Order that this section will appear.
 title = "Featured Publications"
 subtitle = ""
 
+# To include a "See all" link which links to all publications etc set `link_to_more` to "true" (uncomment the below)
+# link_to_more = true
+
 [content]
   # Page type to display. E.g. post, talk, or publication.
   page_type = "publication"

--- a/layouts/partials/widgets/featured.html
+++ b/layouts/partials/widgets/featured.html
@@ -9,6 +9,7 @@
 
 {{/* Query */}}
 {{ $query := where (where site.RegularPages "Type" $items_type) "Params.featured" true }}
+{{ $archive_page := site.GetPage "Section" $items_type }}
 
 {{/* Filters */}}
 {{ if $st.Params.content.filters.tag }}
@@ -31,6 +32,18 @@
 {{/* Limit */}}
 {{ $query = first $items_count $query }}
 
+{{/* Localisation */}}
+{{ $i18n := "" }}
+{{ if eq $items_type "post" }}
+  {{ $i18n = "more_posts" }}
+{{ else if eq $items_type "talk" }}
+  {{ $i18n = "more_talks" }}
+{{ else if eq $items_type "publication" }}
+  {{ $i18n = "more_publications" }}
+{{ else }}
+  {{ $i18n = "more_pages" }}
+{{ end }}
+
 <div class="row">
   <div class="col-12 col-lg-4 section-heading">
     <h1>{{ with $st.Title }}{{ . | markdownify | emojify }}{{ end }}</h1>
@@ -51,6 +64,15 @@
         {{ partial "li_compact" . }}
       {{ end }}
     {{end}}
+
+  {{ if $st.Params.link_to_more }}
+    <div class="see-all">
+      <a href="{{ $archive_page.RelPermalink }}">
+        {{ i18n $i18n | default "See all" }}
+        <i class="fas fa-angle-right"></i>
+      </a>
+    </div>
+  {{ end }}
 
   </div>
 </div>

--- a/layouts/partials/widgets/featured.html
+++ b/layouts/partials/widgets/featured.html
@@ -65,7 +65,7 @@
       {{ end }}
     {{end}}
 
-  {{ if $st.Params.link_to_more }}
+  {{ if $st.Params.content.link_to_archive }}
     <div class="see-all">
       <a href="{{ $archive_page.RelPermalink }}">
         {{ i18n $i18n | default "See all" }}


### PR DESCRIPTION
### Purpose

Adds an option to view "See all" in the featured widget. This links to the archive of *all* publications/pages.

This was requested in #1104 and was closed. 
I wanted this feature too so have implemented it myself, then thought others might want it too.

It does not change any default behaviour, it just adds an extra option. 

The idea of this is when one wants to only display "featured publications" on the homepage but not "recent publications", but still have a clear link from the homepage to all publications.
It is currently possible to manually include such a link as an alert (as suggested in https://github.com/gcushen/hugo-academic/issues/1104#issuecomment-495993127), but I think the display proposed here is nicer. 

### Screenshots

When link_to_more is set to "true" in the featured widget, it displays as

![Screenshot 2020-02-17 at 15 39 52](https://user-images.githubusercontent.com/16070327/74664057-45bdbf80-519d-11ea-8e12-a04f69005260.png)

(or to "all posts" etc as appropriate)

### Documentation

The proposed alteration would need to be added to the snippet on https://github.com/sourcethemes/academic-www/blob/master/content/en/docs/page-builder.md#featured
