### PR TITLE
Non-certificate accomplishments option

### DIFF
--- a/layouts/partials/widgets/accomplishments.html
+++ b/layouts/partials/widgets/accomplishments.html
@@ -40,6 +40,11 @@
               {{ i18n "see_certificate" | default "See certificate" }}
             </a>
           {{ end }}
+          {{ with .details_url }}
+            <a class="card-link" href="{{.}}" target="_blank" rel="noopener">
+              {{ i18n "see_details" | default "See more details" }}
+            </a>
+          {{ end }}
         </div>
       </div>
     {{end}}


### PR DESCRIPTION
### Purpose

Allow users to specify non-certificate related achievements using the accomplishments widget. Note: This will require a change to the i18n YAML files as well, if accepted.

### Documentation

It will be necessary to specify that the user can choose between "certificate_url" or "details_url" in the accomplishments.md file as well as in the documentation.
