### PR TITLE
Allowing markdown link for courses

### DIFF
--- a/layouts/partials/widgets/about.html
+++ b/layouts/partials/widgets/about.html
@@ -95,7 +95,7 @@
           <li>
             <i class="fa-li fas fa-graduation-cap"></i>
             <div class="description">
-              <p class="course">{{ .course }}{{ with .year }}, {{ . }}{{ end }}</p>
+              <p class="course">{{ .course | markdownify }}{{ with .year }}, {{ . }}{{ end }}</p>
               <p class="institution">{{ .institution }}</p>
             </div>
           </li>


### PR DESCRIPTION
### Purpose

Appended `| markdownify` to `.course` to allow markdown links. 

### Details

Normal, unlinked entries are not affected by this change. Entries with markdown links must be entered inside quotation marks (e.g., `"[example](example.com)"`)