### PR TITLE
fix quote strings in errorf calls

### DIFF
--- a/layouts/partials/widget_page.html
+++ b/layouts/partials/widget_page.html
@@ -18,8 +18,8 @@
   {{/* Check widget page exists. */}}
   {{ if not $headless_bundle }}
     {{ errorf "Widget Page not found at %s!" $page }}
-    {{ errorf "View the Widget Page documentation at https://sourcethemes.com/academic/docs/managing-content/#create-a-widget-page . }}
-    {{ errorf "If the Hugo version is between 0.65 and 0.68, it may be a confirmed Hugo bug that is expected to be fixed in Hugo v0.69: https://github.com/gcushen/hugo-academic/issues/1595#issuecomment-605514973 ." }}
+    {{ errorf "View the Widget Page documentation at https://sourcethemes.com/academic/docs/managing-content/#create-a-widget-page" . }}
+    {{ errorf "If the Hugo version is between 0.65 and 0.68, it may be a confirmed Hugo bug that is expected to be fixed in Hugo v0.69: https://github.com/gcushen/hugo-academic/issues/1595#issuecomment-605514973" . }}
   {{ end }}
 {{ end }}
 


### PR DESCRIPTION
### Purpose

Made a new site tonight using up to date Hugo versions and the latest GitHub version of the theme. Got this error:

```
Error: add site dependencies: load resources: loading templates: "/Users/alison/rcourses/dataviz-intro/themes/hugo-academic/layouts/partials/widget_page.html:21:1": parse failed: template: partials/widget_page.html:21: unterminated quoted string
```

Corresponding to the first line here:

https://github.com/gcushen/hugo-academic/blob/8d25dbc61fb5d81d2c7be50f43baae4b78ae6476/layouts/partials/widget_page.html#L21-L22

I attempted a fix to the code, but at the very least there is something wrong here in this partial and the example site will not build as is.
