### PR TITLE
Fix parse error when loading widget_page.html

### DIFF
--- a/layouts/partials/widget_page.html
+++ b/layouts/partials/widget_page.html
@@ -18,7 +18,7 @@
   {{/* Check widget page exists. */}}
   {{ if not $headless_bundle }}
     {{ errorf "Widget Page not found at %s!" $page }}
-    {{ errorf "View the Widget Page documentation at https://sourcethemes.com/academic/docs/managing-content/#create-a-widget-page . }}
+    {{ errorf "View the Widget Page documentation at https://sourcethemes.com/academic/docs/managing-content/#create-a-widget-page ." }}
     {{ errorf "If the Hugo version is between 0.65 and 0.68, it may be a confirmed Hugo bug that is expected to be fixed in Hugo v0.69: https://github.com/gcushen/hugo-academic/issues/1595#issuecomment-605514973 ." }}
   {{ end }}
 {{ end }}


### PR DESCRIPTION
It looks like 8d25dbc61fb5d81d2c7be50f43baae4b78ae6476 introduced the following bug that I ran into when I tried to update my site to the latest master:

```
Error: add site dependencies: load resources: loading templates: "/Users/marpaia/git/website/themes/academic/layouts/partials/widget_page.html:21:1": parse failed: template: partials/widget_page.html:21: unterminated quoted string
```

This is also the bug described in #1618