### PR TITLE
Enhancement request: add parameters to gallery shortcode to fix problem with landscape images on mobiles.

### DIFF
--- a/assets/scss/academic/_root.scss
+++ b/assets/scss/academic/_root.scss
@@ -299,6 +299,18 @@ a[data-fancybox] {
   vertical-align: inherit;
 }
 
+.gallery-automax a[data-fancybox] img {
+  height: auto;
+  width: auto;
+  max-height: 250px;
+  max-width: 320px;
+  display: inherit;
+  margin: 0;
+  padding: 4px;
+  box-shadow: none;
+  vertical-align: inherit;
+}
+
 .fancybox-caption {
   font-size: 1rem;
   line-height: 1.5rem;

--- a/layouts/shortcodes/gallery.html
+++ b/layouts/shortcodes/gallery.html
@@ -2,6 +2,15 @@
 {{ $album := "" }}
 {{ with .Get "album" }}{{ $album = . }}{{else}}{{ $album = "gallery" }}{{end}}
 
+{{/* For page bundles get image resize or default to `x190`. */}}
+{{ $resize := "" }}
+{{ with .Get "resize" }}{{ $resize = . }}{{else}}{{ $resize = "x190" }}{{end}}
+
+{{/* If automax is set to something other than false then limit both max-width and and max-height with CSS for data-fancybox. 
+  Solves a problem with landscape images on mobile phones resulting in a zoomed out page load causing menu to scroll */}}
+{{ $automax := "" }}
+{{ with .Get "automax" }}{{ $automax = "-automax" }}{{end}}
+
 {{/* Set image path and page bundle that images are associated with. */}}
 {{ $album_path := "" }}
 {{ $resource_page := "" }}
@@ -13,13 +22,13 @@
   {{ $resource_page = $.Page }}
 {{ end }}
 
-<div class="gallery">
+<div class="gallery{{$automax}}">
 
   {{/* Attempt to automatically load gallery images from page bundle */}}
   {{ $images := ($resource_page.Resources.ByType "image").Match $album_path }}
   {{ with $images }}
   {{ range $images }}
-    {{ $image := .Resize "x190" }}
+  {{ $image := .Resize $resize }}
     {{/* Check if the user set a caption for this image */}}
     {{ $filename := path.Base .Name }}
     {{ $caption := "" }}


### PR DESCRIPTION
### Summary
This enhancement pull request fixes a specific issue with landscape images using the gallery shortcode on mobile phones. The navbar with its menu icon can scroll in and out of view instead of remaining fixed when such a page is first loaded without this fix. The issue does not apply to desktop PCs.

### What the effect of the fix is
Prevents the menu from scrolling off the page on mobile phones with gallery landscape images when the page is first loaded. 

### What the fix does
Prevent pages with gallery landscape images loading large and so zoomed in on mobile phones. 

### How the fix is applied
The fix is applied by adding a parameter 'automax=true' when using a gallery shortcode.

### Additional request to allow a Hugo resize parameter
Also the default image resize of "x190" (as applied by hugo)  can now be changed with a 'resize' parameter. While this is not relevant to the reported issue, it is a convenient to add it in.

### Default behaviour not affected
If the gallery shortcode is used without these new proposed parameters (automax and resize) then there is no change in behaviour.

Both the parameters only affect page bundles.

## Discussion
To users experienced with using browsers on a mobile phone the issue can not not considered a big problem. However to inexperienced users it is a distressing problem. They find it distressing when the menu icon on a mobile phone disappears and they are convinced there is a fault with the web site.

An experienced user can scroll to bring the navbar menu icon back into view. Zooming out will enable navbar to become fixed again but leave text too small.

By the navbar menu icon I mean the hamburger symbol in the green bar on the top left of
![image](https://user-images.githubusercontent.com/22131790/79704631-9fee1480-82f5-11ea-8ebc-4bf737906e77.png)

Unfortunately the enhancement request requires an additional CSS class, gallery-automax, as added to _root.scss, below the gallery class. If the automax paramter is not specified then the gallery class is used instead.

---

### Using fix and results

**Example of use of gallery shortcode with fix:**
`{{< gallery automax=true >}}`

The results can be viewed from 
https://cairnsmineral.club/member/photoscourses/sat200314/

If you view this page from a PC you can make the menu icon appear by narrowing the width of the browser window.

You can view the two contained landscape images below side by side on a desktop:
![image](https://user-images.githubusercontent.com/22131790/79705032-80f08200-82f7-11ea-93c4-9e694d8bac49.png)

---

On a mobile, with automax parameter set, it appears as:
![image](https://user-images.githubusercontent.com/22131790/79706646-4853a700-82fd-11ea-948c-583433a1d4c5.png)

---

### Effect of not using fix:

**Just leave out the automax parameter or set it to false:**
`{{< gallery >}}`

The above (with the fix) can be contrasted to the effect without the automax parameter.

With no zooming (only scrolling) on a mobile:
![image](https://user-images.githubusercontent.com/22131790/79706681-6a4d2980-82fd-11ea-8435-2aa3a622c68f.png)

Note the landscape image is cropped AND the navbar with menu icon has disappeared. This problem does not occur on desktop PCs.

---

Scrolling considerably to bring the navbar with menu icon back:
![image](https://user-images.githubusercontent.com/22131790/79706765-b13b1f00-82fd-11ea-8b5c-cd3d08d43d31.png)

As you can see even the navbar is cropped.

---

When zooming in to fix navbar so it does not scroll (again automax parameter not set) makes the text too small to see on a mobile:
![image](https://user-images.githubusercontent.com/22131790/79707470-e8aacb00-82ff-11ea-8559-8fecba6dad80.png)

---

Scrolling down from this position on the mobile:
![image](https://user-images.githubusercontent.com/22131790/79707537-290a4900-8300-11ea-9a77-ece018a7e4ff.png)

Note the navbar has not scrolled out of view but the distribution of the images is not optimal and is mixed with text that is too small for a mobile (as seen in previous image).

John Heenan
