### PR TITLE
Accessibility alts and labels

### DIFF
--- a/layouts/partials/li_card.html
+++ b/layouts/partials/li_card.html
@@ -45,7 +45,7 @@
   {{ with $resource }}
   {{ $image := .Fill (printf "918x517 q90 %s" $anchor) }}
   <a href="{{ $item.RelPermalink }}">
-      <img src="{{ $image.RelPermalink }}" class="article-banner" alt="">
+      <img src="{{ $image.RelPermalink }}" class="article-banner" alt="{{ $item.Title }}">
   </a>
   {{end}}
 

--- a/layouts/partials/li_compact.html
+++ b/layouts/partials/li_compact.html
@@ -78,7 +78,7 @@
     {{ with $resource }}
     {{ $image := .Resize "150x" }}
     <a href="{{$link}}" {{ $target | safeHTMLAttr }}>
-      <img src="{{ $image.RelPermalink }}" alt="">
+      <img src="{{ $image.RelPermalink }}" alt="{{ $item.Title }}">
     </a>
     {{end}}
   </div>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -126,7 +126,7 @@
     <ul class="nav-icons navbar-nav flex-row ml-auto d-flex pl-md-2">
       {{ if site.Params.search.engine }}
       <li class="nav-item">
-        <a class="nav-link js-search" href="#"><i class="fas fa-search" aria-hidden="true"></i></a>
+        <a class="nav-link js-search" href="#" aria-label="{{ i18n "search" }}"><i class="fas fa-search" aria-hidden="true"></i></a>
       </li>
       {{ end }}
 


### PR DESCRIPTION
### Purpose

- Added an `alt` string to `li_card.html` and `li_compact.html` using `{{ $item.Title }}`
- Added an `aria-label` to the search icon using `{{ i18n "search" }}`
- Improve accessibility score for Google Lighthouse metrics (https://developers.google.com/web/fundamentals/accessibility)
- Related to #1592

### Screenshots

e.g., 

#### Before

![image](https://user-images.githubusercontent.com/6395915/81810550-2363e580-94f1-11ea-8166-5d8e16756f49.png)

#### After

![image](https://user-images.githubusercontent.com/6395915/81810610-3ecef080-94f1-11ea-92cd-9c2bdc51f87e.png)


### Documentation

n/a
