### PR TITLE
Apply author markdown formatting.

### DIFF
--- a/layouts/partials/li_citation.html
+++ b/layouts/partials/li_citation.html
@@ -5,7 +5,7 @@
   {{ if eq (site.Params.publications.citation_style | default "apa") "apa" }}
 
   <span class="article-metadata li-cite-author">
-    {{ partial "page_metadata_authors" . }}
+    {{ partial "page_metadata_authors" . | markdownify }}
   </span>
   ({{- .Date.Format "2006" -}}).
   <a href="{{ .RelPermalink }}">{{ .Title }}</a>.

--- a/layouts/partials/li_compact.html
+++ b/layouts/partials/li_compact.html
@@ -59,7 +59,7 @@
 
       {{ if and $show_authors_only $item.Params.authors }}
       <div>
-        {{ partial "page_metadata_authors" $item }}
+        {{ partial "page_metadata_authors" $item | markdownify }}
       </div>
       {{ else if not $show_authors_only }}
         {{ partial "page_metadata" (dict "page" $item "is_list" 1) }}

--- a/layouts/partials/page_metadata.html
+++ b/layouts/partials/page_metadata.html
@@ -8,7 +8,7 @@
   {{ $authorLen := len $page.Params.authors }}
   {{ if gt $authorLen 0 }}
   <div>
-    {{ partial "page_metadata_authors" $page }}
+    {{ partial "page_metadata_authors" $page | markdownify }}
   </div>
   {{ end }}
   {{ end }}


### PR DESCRIPTION
### Purpose

I format publications so my name is bold (`**name**`); this has been broken recently so instead of bold `name`, literal `**name**` appears in the author list.

The changes here are sufficient in my setup, there may be other places where `markdownify` is missing.