### PR TITLE
markdown support for authors

### DIFF
--- a/layouts/partials/page_metadata_authors.html
+++ b/layouts/partials/page_metadata_authors.html
@@ -5,7 +5,7 @@
   {{ $link_authors := site.Params.link_authors | default true }}
   {{ range $index, $name_raw := . }}
     {{- $profile_page := site.GetPage (printf "/%s/%s" $taxonomy .) -}}
-    {{- $name := $profile_page.Title | default $name_raw -}}
+    {{- $name := $profile_page.Title | default ($name_raw|markdownify) -}}
     {{- if gt $index 0 }}, {{ end -}}
     <span>
       {{- if and $profile_page $link_authors -}}


### PR DESCRIPTION
### Purpose

The markdown support for "author" was removed in https://github.com/gcushen/hugo-academic/commit/f78feefee90e02ba2d9f06242f4d735dc0271fbf#diff-30d6b470e14d7842de89781a3643dc13.

Issue https://github.com/gcushen/hugo-academic/issues/1652 requests to add markdown support.
Pull request https://github.com/gcushen/hugo-academic/pull/1701 proposes to modify three files (https://github.com/gcushen/hugo-academic/pull/1701/files) respectively. The **markdownify** in the three files not only works for author but also work for **$profile_page.Title**, which is considered as a side effect.

I propose to modify one file (https://github.com/gcushen/hugo-academic/compare/master...vuwjzl17985:fix-authur-markdown?expand=1#diff-30d6b470e14d7842de89781a3643dc13). This pull request is more simple and without side effect.
