### PR TITLE
fix if and for publication

### DIFF
--- a/layouts/publication/single.html
+++ b/layouts/publication/single.html
@@ -11,7 +11,7 @@
     <p class="pub-abstract">{{ .Params.abstract | markdownify }}</p>
     {{ end }}
 
-    {{ if (.Params.publication_types) and (ne (index .Params.publication_types 0) "0") }}
+    {{ if and (.Params.publication_types) (ne (index .Params.publication_types 0) "0") }}
     <div class="row">
       <div class="col-md-1"></div>
       <div class="col-md-10">


### PR DESCRIPTION
### Purpose

Maybe due to Hugo v 0.71.1, I get an error while doing `hugo serve`. This was due to a misplaced `and` in `layouts/publication/single.html` :

```hugo
{{ if (.Params.publication_types) and (ne (index .Params.publication_types 0) "0") }}
```

The `and` has been moved right after the `if`:
```hugo
{{ if and (.Params.publication_types) (ne (index .Params.publication_types 0) "0") }}
```

The error log:
```bash
Building sites … ERROR 2020/05/26 10:17:34 render of "page" failed: "/home/bertrand/src/webpage_cnrs/themes/academic/layouts/publication/single.html:14:10": execute of template failed: template: publication/single.html:14:10: executing "main" at <(.Params.publication_types) and (ne (index .Params.publication_types 0) "0")>: can't give argument to non-function .Params.publication_types
```
