### PR TITLE
edit background color for pre, code in CSS

### DIFF
--- a/assets/scss/academic/_dark.scss
+++ b/assets/scss/academic/_dark.scss
@@ -39,7 +39,7 @@ body.dark,
 }
 
 .dark pre {
-  background-color: rgb(68, 71, 90);
+  /* Match `pre` bg color above. */
   border-color: rgb(68, 71, 90);
 }
 

--- a/assets/scss/academic/_root.scss
+++ b/assets/scss/academic/_root.scss
@@ -168,13 +168,12 @@ pre,
 code {
   font-family: $sta-font-mono, monospace;
   color: #c7254e;
-  /* Match default highlight theme. */
-  background-color: #f8f8f8;
+  /* Match bg of default highlight theme. */
+  background-color: rgb(248, 248, 248);
 }
 
 pre {
   margin: 0 0 1rem 0;
-  background-color: rgb(248, 248, 248); /* Match default highlight theme. */
   border-color: rgb(248, 248, 248);
   font-size: 0.7rem;
   border-radius: 4px;

--- a/assets/scss/academic/_root.scss
+++ b/assets/scss/academic/_root.scss
@@ -168,7 +168,8 @@ pre,
 code {
   font-family: $sta-font-mono, monospace;
   color: #c7254e;
-  background-color: #f9f2f4;
+  /* Match default highlight theme. */
+  background-color: #f8f8f8;
 }
 
 pre {

--- a/assets/scss/academic/_root.scss
+++ b/assets/scss/academic/_root.scss
@@ -174,6 +174,7 @@ code {
 
 pre {
   margin: 0 0 1rem 0;
+  /* Match bg of default highlight theme. */
   border-color: rgb(248, 248, 248);
   font-size: 0.7rem;
   border-radius: 4px;


### PR DESCRIPTION
### Purpose

I believe this small piece of the CSS is in error (at least, I hope it is!). The current CSS background color I believe is overridden by highlightjs, so you would only notice it if not using highlightjs. In this case, I think the better default background color is to match the background color set in the CSS just below this one.

### Screenshots

Before:
```
pre,
code {
  font-family: $sta-font-mono, monospace;
  color: #c7254e;
  background-color: #f9f2f4; <-- this is pink!
}

pre {
  margin: 0 0 1rem 0;
  background-color: rgb(248, 248, 248); /* Match default highlight theme. */
  border-color: rgb(248, 248, 248);
  font-size: 0.7rem;
  border-radius: 4px;
}
```
<img width="785" alt="Screen Shot 2020-06-08 at 9 23 05 AM" src="https://user-images.githubusercontent.com/12160301/84092955-be939200-a9ad-11ea-89ec-e383d2434412.png">

After:
```
pre,
code {
  font-family: $sta-font-mono, monospace;
  color: #c7254e;
  /* Match default highlight theme. */
  background-color: #f8f8f8; <-- this is gray
}

pre {
  margin: 0 0 1rem 0;
  background-color: rgb(248, 248, 248); /* Match default highlight theme. */
  border-color: rgb(248, 248, 248);
  font-size: 0.7rem;
  border-radius: 4px;
}
```
<img width="1401" alt="Screen Shot 2020-06-08 at 5 36 40 PM" src="https://user-images.githubusercontent.com/12160301/84093287-a83a0600-a9ae-11ea-920c-c9c4b4a43725.png">

### Documentation

I don't think documentation changes are needed.
