### PR TITLE
fix: SVG images break figure shortcode.

### DIFF
--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -1,8 +1,14 @@
 {{/* Enable image to be loaded from local page dir or media library at `static/img/`. */}}
 
 {{ $asset := (.Page.Resources.ByType "image").GetMatch (.Get "src") }}
-{{ $image_src := (.Get "src") }}
+{{ $is_svg := false }}
 {{ if $asset }}
+  {{ if eq $asset.MediaType.SubType "svg"}}
+    {{ $is_svg = true }}
+  {{ end }}
+{{ end }}
+{{ $image_src := (.Get "src") }}
+{{ if and ($asset) (not ($is_svg)) }}
   {{ $asset2 := $asset.Fit "2000x2000" }}
   {{ $image_src = $asset2.RelPermalink }}
 {{ else if .Get "library" }}
@@ -27,7 +33,7 @@
 {{ end -}}
 
 {{/* Lazy load only when we know image dimensions in order to preserve anchor linking. */}}
-{{ if $asset }}
+{{ if and ($asset) (not ($is_svg)) }}
   <img data-src="{{$image_src}}" class="lazyload" alt="{{ with .Get "alt" }}{{.}}{{end}}" width="{{ (.Get "width") | default $asset.Width }}" height="{{ (.Get "height") | default $asset.Height }}">
 {{ else if and (.Get "width") (.Get "height") }}
   <img data-src="{{$image_src}}" class="lazyload" alt="{{ with .Get "alt" }}{{.}}{{end}}" {{ with .Get "width" }}width="{{.}}"{{end}} {{ with .Get "height" }}height="{{.}}"{{end}}>

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -8,7 +8,7 @@
   {{ end }}
 {{ end }}
 {{ $image_src := (.Get "src") }}
-{{ if and ($asset) (not ($is_svg)) }}
+{{ if and $asset (not $is_svg) }}
   {{ $asset2 := $asset.Fit "2000x2000" }}
   {{ $image_src = $asset2.RelPermalink }}
 {{ else if .Get "library" }}
@@ -33,7 +33,7 @@
 {{ end -}}
 
 {{/* Lazy load only when we know image dimensions in order to preserve anchor linking. */}}
-{{ if and ($asset) (not ($is_svg)) }}
+{{ if and $asset (not $is_svg) }}
   <img data-src="{{$image_src}}" class="lazyload" alt="{{ with .Get "alt" }}{{.}}{{end}}" width="{{ (.Get "width") | default $asset.Width }}" height="{{ (.Get "height") | default $asset.Height }}">
 {{ else if and (.Get "width") (.Get "height") }}
   <img data-src="{{$image_src}}" class="lazyload" alt="{{ with .Get "alt" }}{{.}}{{end}}" {{ with .Get "width" }}width="{{.}}"{{end}} {{ with .Get "height" }}height="{{.}}"{{end}}>


### PR DESCRIPTION
### Purpose

Fixes #1620 

The current figure shortcode implementation tries to resize "image" resources and for others it just creates an <img> link.

The problem is, Hugo returns SVG for .Page.Resources.ByType "image", but does not support Fit. However, I fixed it for my site by additionally checking if .MediaType.SubType is equal to svg and skipping .Fit for those.

