### PR TITLE
Add link to publication

### DIFF
--- a/archetypes/publication/index.md
+++ b/archetypes/publication/index.md
@@ -15,9 +15,10 @@ publishDate: {{ .Date }}
 # 7 = Thesis; 8 = Patent
 publication_types: ["0"]
 
-# Publication name and optional abbreviated publication name.
+# Publication name and optional abbreviated publication name + URL
 publication: ""
 publication_short: ""
+publication_url: ""
 
 abstract: ""
 


### PR DESCRIPTION
Use parameter `publication_url` to add a link to the publication name

### Purpose

Use parameter `publication_url` to add a link to the publication name such as it is done with talks where one can pass the URL of the event.