### PR TITLE
Add blogmail integration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - **Create content** in [**Markdown**](https://sourcethemes.com/academic/docs/writing-markdown-latex/), [**Jupyter**](https://sourcethemes.com/academic/docs/jupyter/), or [**RStudio**](https://sourcethemes.com/academic/docs/install/#install-with-rstudio)
 - **Plugin System** - Fully customizable [**color** and **font themes**](https://sourcethemes.com/academic/themes/)
 - **Display Code and Math** - Code highlighting and [LaTeX math](https://en.wikibooks.org/wiki/LaTeX/Mathematics) supported
-- **Integrations** - [Google Analytics](https://analytics.google.com), [Disqus commenting](https://disqus.com), Maps, Contact Forms, and more!
+- **Integrations** - [Google Analytics](https://analytics.google.com), [Disqus commenting](https://disqus.com), [blogmail](https://blogmail.co/), Maps, Contact Forms, and more!
 - **Beautiful Site** - Simple and refreshing one page design
 - **Industry-Leading SEO** - Help get your website found on search engines and social media
 - **Media Galleries** - Display your images and videos with captions in a customizable gallery

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -296,3 +296,19 @@ plugins_js  = []
 ############################
 [icon.pack]
   ai = false  # Academicons icon pack https://jpswalsh.github.io/academicons/
+
+############################
+## Email newsletter
+############################
+[newsletter]
+  # Newsletter provider:
+  #   0: Disabled
+  #   1: blogmail (https://blogmail.co)
+  engine = 0
+
+  # Which page types show email subscription form?
+  subscribable = {page = true, post = true, docs = true, project = true, publication = true, talk = true}
+
+  # Configuration of blogmail.
+  [newsletter.blogmail]
+    newsletterId = ""  # Paste the newsletter ID from your blogmail dashboard.

--- a/layouts/partials/book_layout.html
+++ b/layouts/partials/book_layout.html
@@ -45,6 +45,8 @@
 
           {{ partial "page_edit" . }}
 
+          {{ partial "newsletter" . }}
+
           {{ partial "comments" . }}
 
           {{ partial "page_related" . }}

--- a/layouts/partials/docs_layout.html
+++ b/layouts/partials/docs_layout.html
@@ -43,6 +43,8 @@
 
           {{ partial "page_edit" . }}
 
+          {{ partial "newsletter" . }}
+
           {{ partial "comments" . }}
 
           {{ partial "page_related" . }}

--- a/layouts/partials/newsletter.html
+++ b/layouts/partials/newsletter.html
@@ -1,0 +1,7 @@
+{{ if site.Params.newsletter.engine | and (index site.Params.newsletter.subscribable .Type) | and (ne .Params.newsletter.subscribable false) | or .Params.newsletter.subscribable }}
+<section id="newsletter">
+  {{ if eq site.Params.newsletter.engine 1 }}
+    {{ partial "newsletter/blogmail.html" . }}
+  {{ end }}
+</section>
+{{ end }}

--- a/layouts/partials/newsletter/blogmail.html
+++ b/layouts/partials/newsletter/blogmail.html
@@ -1,0 +1,23 @@
+{{ if site.Params.newsletter.blogmail.newsletterId }}
+<div class="blogmail border rounded container-fluid py-3 mt-2">
+  <script type="application/json">
+    {
+      "newsletterId": "{{site.Params.newsletter.blogmail.newsletterId}}",
+      "inputPlaceholder": "your email",
+      "labelText": "Get notified by email when there's a new post",
+      "buttonText": "Subscribe",
+      "subscribedText": "Subscribed! 😀",
+      "classes": {
+        "a": "",
+        "formDiv": "form-group container d-flex flex-wrap",
+        "bottomDiv": "small gray-light container flex-wrap",
+        "subscribedDiv": "",
+        "label": "",
+        "textInput": "rounded flex-grow-1 px-1",
+        "submitInput": "btn btn-default border flex-wrap mx-1"
+      }
+    }
+  </script>
+</div>
+<script async src="https://blogmail.co/v1/bm.js"></script>
+{{end}}

--- a/layouts/partials/page_footer.html
+++ b/layouts/partials/page_footer.html
@@ -1,6 +1,7 @@
 {{ partial "page_edit" . }}
 {{ partial "tags" . }}
 {{ partial "share" . }}
+{{ partial "newsletter" . }}
 {{ partial "page_author" . }}
 {{ partial "comments" . }}
 


### PR DESCRIPTION
### Purpose

Newsletters are a popular way to help publishers reach an audience. [blogmail](https://blogmail.co/) is a simple privacy-focused newsletter service with a free tier. This PR adds integration for the service.

### Screenshots

From the example site with light and dark themes:

<img width="780" alt="Screen Shot 2020-07-27 at 4 05 14 PM" src="https://user-images.githubusercontent.com/3129093/88586843-fe2c4100-d022-11ea-813c-d9b5f70cc28e.png">
<img width="797" alt="Screen Shot 2020-07-27 at 4 05 05 PM" src="https://user-images.githubusercontent.com/3129093/88586845-ff5d6e00-d022-11ea-9094-a4b62adf8016.png">


### Documentation

I will follow-up shortly with a documentation PR once there's some feedback on these changes (assuming they're acceptable).