### PR TITLE
:sparkles: Adding support for 'shared first authors'

### DIFF
--- a/layouts/partials/page_metadata_authors.html
+++ b/layouts/partials/page_metadata_authors.html
@@ -6,6 +6,8 @@
   {{ range $index, $name_raw := . }}
     {{- $profile_page := site.GetPage (printf "/%s/%s" $taxonomy .) -}}
     {{- $name := $profile_page.Title | default $name_raw -}}
+    {{- $shared_1st := in $name_raw "*" -}}
+    {{- if $shared_1st -}}{{- $name = printf "%s*" $name -}}{{- end -}}
     {{- if gt $index 0 }}, {{ end -}}
     <span {{ if site.Params.highlight_superuser | and (eq $profile_page.Params.superuser true) }}class="font-weight-bold"{{end}}>
       {{- if and $profile_page $link_authors -}}


### PR DESCRIPTION
### Purpose

Papers seem to be increasing in shared first authorship (potential confirmation bias here). This commit allows for `hugo-academic` to properly parse out that shared authorship when denoted by a "*".

In my experience, `{{ ... | markdownify }}` tends to obliterate the `*`, or worse if one attempts `**<author>***`.

### Screenshots

![image](https://user-images.githubusercontent.com/5000729/89860479-8b1de100-db71-11ea-9ab3-524e2fe0131a.png)

### Documentation

When adding authors, you may specify shared authorship with a `*`.
